### PR TITLE
Fix Netlify SPA routing and add blank build option

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm run build:client"
+  command = "npm run build:blank"
   functions = "netlify/functions"
   publish = "dist/spa"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm run build:blank"
+  command = "npm run build:client"
   functions = "netlify/functions"
   publish = "dist/spa"
 
@@ -7,9 +7,15 @@
 [functions]
   external_node_modules = ["express"]
   node_bundler = "esbuild"
-  
+
 [[redirects]]
   force = true
   from = "/api/*"
   status = 200
   to = "/.netlify/functions/api/:splat"
+
+# SPA fallback: send all other routes to index.html
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build",
     "build:server": "vite build --config vite.config.server.ts",
+    "build:blank": "node scripts/blank-build.mjs",
     "start": "node dist/server/node-build.mjs",
     "test": "vitest --run",
     "format.fix": "prettier --write .",

--- a/scripts/blank-build.mjs
+++ b/scripts/blank-build.mjs
@@ -1,0 +1,38 @@
+import { rmSync, mkdirSync, writeFileSync, existsSync } from "fs";
+import { join } from "path";
+
+const outDir = join(process.cwd(), "dist", "spa");
+
+try {
+  if (existsSync(outDir)) rmSync(outDir, { recursive: true, force: true });
+  mkdirSync(outDir, { recursive: true });
+
+  const html = `<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>DBT Salud — Deploy OK</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body { margin: 0; min-height: 100vh; display: grid; place-items: center; font: 16px/1.5 system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji"; background: #f9fafb; color: #111827; }
+    main { text-align: center; }
+    h1 { font-size: 2rem; margin: 0 0 .25rem; }
+    p { margin: 0; color: #374151; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Deploy OK</h1>
+    <p>Versión en blanco temporal</p>
+  </main>
+</body>
+</html>`;
+
+  writeFileSync(join(outDir, "index.html"), html);
+  writeFileSync(join(outDir, "200.html"), html);
+  console.log("Blank build created at", outDir);
+} catch (err) {
+  console.error("Failed to create blank build:", err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Purpose

The user was experiencing issues with Netlify deployments where the site was rendering a blank page and client-side routes were failing with 404 errors. They needed to fix the production build to ensure proper SPA routing functionality and have a working deployment at https://dbt-web.netlify.app/ with all routes accessible.

## Code changes

- **Added SPA fallback redirect** in `netlify.toml` to route all requests to `/index.html` with status 200, enabling proper client-side routing
- **Created blank build script** (`scripts/blank-build.mjs`) that generates a minimal HTML page for temporary deployments
- **Added build command** `build:blank` in `package.json` to run the blank build script when needed

These changes ensure that direct URL access to sub-routes (like `/login`, `/dashboard`) will work correctly instead of returning 404 errors, and provide a fallback option for quick deployments.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/93855f88c32d420fac57696471367434/zenith-sanctuary)

👀 [Preview Link](https://93855f88c32d420fac57696471367434-zenith-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>93855f88c32d420fac57696471367434</projectId>-->
<!--<branchName>zenith-sanctuary</branchName>-->