### PR TITLE
Unify Contentful style and content components

### DIFF
--- a/client/components/admin/AdminAccessList.tsx
+++ b/client/components/admin/AdminAccessList.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+
+type Props = {
+  adminUser: string;
+};
+
+export default function AdminAccessList({ adminUser }: Props) {
+  return (
+    <section className="space-y-4 bg-white rounded-xl border shadow-sm p-4">
+      <div className="flex items-start justify-between gap-3 flex-wrap">
+        <div>
+          <h2 className="text-base font-semibold">Usuarios con acceso al panel</h2>
+          <p className="text-sm text-gray-600 mt-1">
+            El acceso a <span className="font-medium">/admin</span> se valida con
+            usuario/contraseña configurados en variables de entorno.
+            <span className="font-medium"> La contraseña no se muestra</span> por
+            seguridad.
+          </p>
+        </div>
+      </div>
+
+      <div className="overflow-auto border rounded-lg">
+        <table className="min-w-full text-sm">
+          <thead className="bg-[rgb(248,250,252)] text-gray-600">
+            <tr>
+              <th className="text-left font-medium px-4 py-3">Usuario</th>
+              <th className="text-left font-medium px-4 py-3">Acceso</th>
+              <th className="text-left font-medium px-4 py-3">Método</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr className="border-t">
+              <td className="px-4 py-3 font-mono">{adminUser}</td>
+              <td className="px-4 py-3">Panel completo (Contenido / Estilos / Traductor)</td>
+              <td className="px-4 py-3">Usuario + contraseña (Basic)</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div className="text-xs text-gray-500">
+        Para cambiar las credenciales, define <span className="font-mono">VITE_ADMIN_USER</span> y{" "}
+        <span className="font-mono">VITE_ADMIN_PASSWORD</span> en el entorno del
+        servidor.
+      </div>
+    </section>
+  );
+}

--- a/client/components/admin/AdminLayout.tsx
+++ b/client/components/admin/AdminLayout.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { FileText, Palette, Languages, LayoutGrid } from "lucide-react";
+import { FileText, Palette, Languages, LayoutGrid, Users } from "lucide-react";
 
-export type AdminNavKey = "content" | "styles" | "translate";
+export type AdminNavKey = "content" | "styles" | "translate" | "access";
 
 type NavItem = { key: AdminNavKey; label: string; icon: React.ReactNode };
 
@@ -16,6 +16,7 @@ const NAV_ITEMS: NavItem[] = [
   { key: "content", label: "Contenido", icon: <FileText size={16} /> },
   { key: "styles", label: "Estilos", icon: <Palette size={16} /> },
   { key: "translate", label: "Traductor", icon: <Languages size={16} /> },
+  { key: "access", label: "Accesos", icon: <Users size={16} /> },
 ];
 
 type Props = {

--- a/client/lib/cms.ts
+++ b/client/lib/cms.ts
@@ -161,13 +161,21 @@ export async function upsertContent<T = any>(
   if (res.ok === false) throw new Error(res.error);
 }
 
-export async function listContentKeys(prefix?: string): Promise<string[]> {
+export type CmsBackend = "contentful" | "supabase" | "local";
+
+export async function listContentKeys(
+  prefix?: string,
+): Promise<{ keys: string[]; backend?: CmsBackend }> {
   const url = prefix
     ? `${API_BASE}/keys?prefix=${encodeURIComponent(prefix)}`
     : `${API_BASE}/keys`;
-  const res = await apiFetchJson<{ keys: string[] }>(url);
+  const res = await apiFetchJson<{ keys: string[]; backend?: CmsBackend }>(url);
   if (res.ok === false) throw new Error(res.error);
-  return Array.from(new Set(res.data.keys)).sort();
+
+  return {
+    keys: Array.from(new Set(res.data.keys)).sort(),
+    backend: res.data.backend,
+  };
 }
 
 // SETTINGS

--- a/client/lib/cms.ts
+++ b/client/lib/cms.ts
@@ -214,6 +214,10 @@ export type SeedContentfulResult = {
     styleKeys: string[];
     settings: true;
   };
+  warnings?: string[];
+  structured?: {
+    stylesEnabled?: boolean;
+  };
 };
 
 export async function seedContentful(): Promise<SeedContentfulResult> {

--- a/client/lib/cms.ts
+++ b/client/lib/cms.ts
@@ -9,18 +9,25 @@ async function apiFetchJson<T>(
 ): Promise<
   { ok: true; data: T } | { ok: false; error: string; status?: number }
 > {
-  const controller = new AbortController();
-  const timeoutMs = opts?.timeoutMs ?? 15_000;
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-
+  const timeoutMs = Math.max(1_000, opts?.timeoutMs ?? 15_000);
   const retries = Math.max(0, opts?.retries ?? 0);
   const retryDelayMs = Math.max(0, opts?.retryDelayMs ?? 500);
 
-  async function attempt(
-    remaining: number,
-  ): Promise<
-    { ok: true; data: T } | { ok: false; error: string; status?: number }
-  > {
+  const isLikelyAbortMessage = (msg: string) =>
+    msg.toLowerCase().includes("aborted") ||
+    msg.toLowerCase().includes("abort") ||
+    msg.toLowerCase().includes("signal is aborted");
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => {
+      try {
+        controller.abort();
+      } catch {
+        // ignore
+      }
+    }, timeoutMs);
+
     try {
       const res = await fetch(input, {
         ...init,
@@ -68,28 +75,35 @@ async function apiFetchJson<T>(
 
       return { ok: true, data: json as T };
     } catch (e: any) {
-      const message = e?.message || String(e);
-      const isAbort = e?.name === "AbortError";
+      const rawMessage = e?.message || String(e);
+      const isAbort =
+        e?.name === "AbortError" ||
+        rawMessage === "signal is aborted without reason" ||
+        isLikelyAbortMessage(rawMessage);
+
+      const message = isAbort
+        ? `Request timed out after ${timeoutMs}ms`
+        : rawMessage;
+
       const isNetwork =
         !isAbort &&
-        (message === "Failed to fetch" ||
-          message.toLowerCase().includes("network") ||
-          message.toLowerCase().includes("load failed"));
+        (rawMessage === "Failed to fetch" ||
+          rawMessage.toLowerCase().includes("network") ||
+          rawMessage.toLowerCase().includes("load failed"));
 
-      if (isNetwork && remaining > 0) {
+      const canRetry = (isNetwork || isAbort) && attempt < retries;
+      if (canRetry) {
         await new Promise((r) => setTimeout(r, retryDelayMs));
-        return attempt(remaining - 1);
+        continue;
       }
 
       return { ok: false, error: message };
+    } finally {
+      clearTimeout(timeout);
     }
   }
 
-  try {
-    return await attempt(retries);
-  } finally {
-    clearTimeout(timeout);
-  }
+  return { ok: false, error: "Unknown error" };
 }
 
 function getAdminAuthHeader(): string | undefined {

--- a/client/lib/cms.ts
+++ b/client/lib/cms.ts
@@ -150,7 +150,11 @@ export async function fetchContent<T = any>(
   locale: Locale,
 ): Promise<T | null> {
   const url = `${API_BASE}/content?key=${encodeURIComponent(key)}&locale=${encodeURIComponent(locale)}`;
-  const res = await apiFetchJson<{ data: T | null }>(url);
+  const res = await apiFetchJson<{ data: T | null }>(url, undefined, {
+    timeoutMs: 25_000,
+    retries: 1,
+    retryDelayMs: 600,
+  });
   if (res.ok === false) {
     console.error("fetchContent error", res.error);
     return null;
@@ -197,7 +201,7 @@ export async function fetchSiteSettings(): Promise<SiteSettings | null> {
   const res = await apiFetchJson<{ settings: SiteSettings | null }>(
     `${API_BASE}/settings`,
     undefined,
-    { retries: 1, retryDelayMs: 600 },
+    { retries: 1, retryDelayMs: 600, timeoutMs: 25_000 },
   );
   if (res.ok === false) {
     console.error("fetchSiteSettings error", res.error);

--- a/client/pages/Admin.tsx
+++ b/client/pages/Admin.tsx
@@ -10,6 +10,7 @@ import {
   listContentKeys,
   seedContentful,
   type Locale,
+  type CmsBackend,
 } from "@/lib/cms";
 import { applyTheme } from "@/lib/theme";
 import { autoTranslate } from "@/lib/translate";
@@ -44,6 +45,7 @@ export default function Admin() {
   const [rawJson, setRawJson] = useState<string>("{}");
   const [saving, setSaving] = useState(false);
   const [editorMode, setEditorMode] = useState<"json" | "form">("form");
+  const [cmsBackend, setCmsBackend] = useState<CmsBackend | null>(null);
 
   const [seeding, setSeeding] = useState(false);
   const [seedStatus, setSeedStatus] = useState<
@@ -89,10 +91,13 @@ export default function Admin() {
     loadSettings();
     (async () => {
       try {
-        const keys = await listContentKeys("luminous.");
+        const { keys, backend } = await listContentKeys("luminous.");
+        if (backend) setCmsBackend(backend);
         if (keys.length)
           setAvailableKeys(Array.from(new Set([...defaultKeys, ...keys])));
-      } catch {}
+      } catch {
+        // ignore
+      }
     })();
   }, [authed]);
 
@@ -223,7 +228,8 @@ export default function Admin() {
       await loadSettings();
 
       try {
-        const keys = await listContentKeys("luminous.");
+        const { keys, backend } = await listContentKeys("luminous.");
+        if (backend) setCmsBackend(backend);
         if (keys.length)
           setAvailableKeys(Array.from(new Set([...defaultKeys, ...keys])));
       } catch {
@@ -456,7 +462,8 @@ export default function Admin() {
       );
       await upsertContent("luminous.footer", "en", en.footer);
 
-      const keys = await listContentKeys("luminous.");
+      const { keys, backend } = await listContentKeys("luminous.");
+      if (backend) setCmsBackend(backend);
       if (keys.length)
         setAvailableKeys(Array.from(new Set([...defaultKeys, ...keys])));
       alert("Contenido migrado desde Luminous");

--- a/client/pages/Admin.tsx
+++ b/client/pages/Admin.tsx
@@ -961,7 +961,17 @@ export default function Admin() {
 
       {tab === "translate" && (
         <section className="space-y-4 bg-white rounded-xl border shadow-sm p-4">
-          <TranslatorTool />
+          {contentfulReadOnly ? (
+            <div className="rounded-md border bg-amber-50 p-3 text-sm text-amber-900">
+              <div className="font-medium">Traducciones administradas en Contentful</div>
+              <div className="text-xs text-amber-800">
+                Para mantener Contentful como fuente única, esta herramienta queda deshabilitada.
+                Gestiona los locales (ES/EN) desde Contentful.
+              </div>
+            </div>
+          ) : (
+            <TranslatorTool />
+          )}
         </section>
       )}
     </AdminLayout>

--- a/client/pages/Admin.tsx
+++ b/client/pages/Admin.tsx
@@ -558,6 +558,29 @@ export default function Admin() {
     onClick: () => setSelectedStyleKey(k),
   }));
 
+  const contentfulReadOnly = cmsBackend === "contentful";
+
+  const copyToClipboard = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      alert("Copiado");
+    } catch {
+      try {
+        const ta = document.createElement("textarea");
+        ta.value = text;
+        ta.style.position = "fixed";
+        ta.style.left = "-9999px";
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand("copy");
+        document.body.removeChild(ta);
+        alert("Copiado");
+      } catch {
+        alert("No se pudo copiar");
+      }
+    }
+  };
+
   return (
     <AdminLayout
       active={tab}

--- a/client/pages/Admin.tsx
+++ b/client/pages/Admin.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import JsonFormEditor from "@/components/admin/JsonFormEditor";
 import AdminLayout from "@/components/admin/AdminLayout";
+import AdminAccessList from "@/components/admin/AdminAccessList";
 import {
   fetchContent,
   upsertContent,
@@ -16,7 +17,7 @@ import { autoTranslate } from "@/lib/translate";
 const ADMIN_USER = import.meta.env.VITE_ADMIN_USER || "admin";
 const ADMIN_PASSWORD = import.meta.env.VITE_ADMIN_PASSWORD || "qpsych2025!";
 
-type Tab = "content" | "styles" | "translate";
+type Tab = "content" | "styles" | "translate" | "access";
 
 const defaultKeys = [
   "luminous.seo",
@@ -824,6 +825,8 @@ export default function Admin() {
           </div>
         </section>
       )}
+
+      {tab === "access" && <AdminAccessList adminUser={ADMIN_USER} />}
 
       {tab === "translate" && (
         <section className="space-y-4 bg-white rounded-xl border shadow-sm p-4">

--- a/client/pages/Admin.tsx
+++ b/client/pages/Admin.tsx
@@ -728,6 +728,14 @@ export default function Admin() {
 
       {tab === "styles" && selectedStyleKey === "luminous.styles.generales" && (
         <section className="space-y-6 bg-white rounded-xl border shadow-sm p-4">
+          {contentfulReadOnly && (
+            <div className="rounded-md border bg-amber-50 p-3 text-sm text-amber-900">
+              <div className="font-medium">Estilos administrados en Contentful</div>
+              <div className="text-xs text-amber-800">
+                Para mantener Contentful como fuente única, esta sección queda en <span className="font-medium">modo lectura</span>.
+              </div>
+            </div>
+          )}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="space-y-4">
               <div>
@@ -743,13 +751,15 @@ export default function Admin() {
                         : "#" + primary.replace(/[^0-9a-fA-F]/g, "")
                     }
                     onChange={(e) => setPrimary(e.target.value)}
-                    className="h-10 w-14 p-0 border rounded"
+                    disabled={contentfulReadOnly}
+                    className="h-10 w-14 p-0 border rounded disabled:opacity-50 disabled:cursor-not-allowed"
                   />
                   <input
                     type="text"
                     value={primary}
                     onChange={(e) => setPrimary(e.target.value)}
-                    className="flex-1 border rounded-md px-3 py-2 font-mono"
+                    disabled={contentfulReadOnly}
+                    className="flex-1 border rounded-md px-3 py-2 font-mono disabled:opacity-50 disabled:cursor-not-allowed"
                   />
                 </div>
               </div>
@@ -766,13 +776,15 @@ export default function Admin() {
                         : "#" + secondary.replace(/[^0-9a-fA-F]/g, "")
                     }
                     onChange={(e) => setSecondary(e.target.value)}
-                    className="h-10 w-14 p-0 border rounded"
+                    disabled={contentfulReadOnly}
+                    className="h-10 w-14 p-0 border rounded disabled:opacity-50 disabled:cursor-not-allowed"
                   />
                   <input
                     type="text"
                     value={secondary}
                     onChange={(e) => setSecondary(e.target.value)}
-                    className="flex-1 border rounded-md px-3 py-2 font-mono"
+                    disabled={contentfulReadOnly}
+                    className="flex-1 border rounded-md px-3 py-2 font-mono disabled:opacity-50 disabled:cursor-not-allowed"
                   />
                 </div>
               </div>
@@ -783,7 +795,8 @@ export default function Admin() {
                 <select
                   value={fontFamily}
                   onChange={(e) => setFontFamily(e.target.value)}
-                  className="w-full border rounded-md px-3 py-2"
+                  disabled={contentfulReadOnly}
+                  className="w-full border rounded-md px-3 py-2 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {fontsLoading && <option>Cargando fuentes…</option>}
                   {!fontsLoading && (
@@ -807,7 +820,8 @@ export default function Admin() {
                   max={24}
                   value={baseSize}
                   onChange={(e) => setBaseSize(Number(e.target.value))}
-                  className="w-full border rounded-md px-3 py-2"
+                  disabled={contentfulReadOnly}
+                  className="w-full border rounded-md px-3 py-2 disabled:opacity-50 disabled:cursor-not-allowed"
                 />
               </div>
               <div>
@@ -818,7 +832,8 @@ export default function Admin() {
                   type="text"
                   value={logoUrl}
                   onChange={(e) => setLogoUrl(e.target.value)}
-                  className="w-full border rounded-md px-3 py-2"
+                  disabled={contentfulReadOnly}
+                  className="w-full border rounded-md px-3 py-2 disabled:opacity-50 disabled:cursor-not-allowed"
                 />
               </div>
             </div>
@@ -844,7 +859,8 @@ export default function Admin() {
           <div>
             <button
               onClick={handleApplyTheme}
-              className="px-4 py-2 bg-stone-900 text-white rounded-md"
+              disabled={contentfulReadOnly}
+              className="px-4 py-2 bg-stone-900 text-white rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Guardar y aplicar
             </button>

--- a/client/pages/Admin.tsx
+++ b/client/pages/Admin.tsx
@@ -634,6 +634,16 @@ export default function Admin() {
               )}
             </div>
           )}
+
+          {contentfulReadOnly && (
+            <div className="rounded-md border bg-amber-50 p-3 text-sm text-amber-900">
+              <div className="font-medium">Contenido administrado en Contentful</div>
+              <div className="text-xs text-amber-800">
+                Esta pantalla queda en <span className="font-medium">modo lectura</span> para evitar sobrescribir el modelo estructurado.
+                Edita títulos, textos, links, imágenes y estilos directamente desde Contentful.
+              </div>
+            </div>
+          )}
           {/* <div className="grid grid-cols-1 md:grid-cols-2 gap-6"> */}
           <div className="grid grid-cols-1 gap-6">
             <div>
@@ -645,48 +655,72 @@ export default function Admin() {
               </div>
             </div>
             <div>
-              <div className="flex items-center justify-between mb-1">
-                <label className="block text-sm font-medium">
-                  Editor ({locale})
-                </label>
-                <div className="inline-flex border rounded-md overflow-hidden">
-                  <button
-                    onClick={() => setEditorMode("form")}
-                    className={`px-3 py-1 text-sm ${editorMode === "form" ? "bg-stone-900 text-white" : "bg-white"}`}
-                  >
-                    Formulario
-                  </button>
-                  <button
-                    onClick={() => setEditorMode("json")}
-                    className={`px-3 py-1 text-sm ${editorMode === "json" ? "bg-stone-900 text-white" : "bg-white"}`}
-                  >
-                    JSON
-                  </button>
+              {contentfulReadOnly ? (
+                <div className="space-y-2">
+                  <label className="block text-sm font-medium">
+                    Contenido (solo lectura · {locale})
+                  </label>
+                  <div className="w-full h-[460px] border rounded-md bg-gray-50 overflow-auto">
+                    <pre className="p-3 text-xs whitespace-pre-wrap font-mono">
+                      {rawJson}
+                    </pre>
+                  </div>
+                  <div className="mt-3 flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => copyToClipboard(rawJson)}
+                      className="px-4 py-2 border rounded-md text-sm bg-white hover:bg-gray-50"
+                    >
+                      Copiar JSON
+                    </button>
+                  </div>
                 </div>
-              </div>
-              {editorMode === "json" ? (
-                <textarea
-                  value={rawJson}
-                  onChange={(e) => setRawJson(e.target.value)}
-                  className="w-full h-[460px] border rounded-md p-3 font-mono text-sm"
-                />
               ) : (
-                <div className="w-full h-[460px] border rounded-md bg-gray-50 overflow-auto">
-                  <JsonFormEditor
-                    jsonText={rawJson}
-                    onChangeJsonText={setRawJson}
-                  />
-                </div>
+                <>
+                  <div className="flex items-center justify-between mb-1">
+                    <label className="block text-sm font-medium">
+                      Editor ({locale})
+                    </label>
+                    <div className="inline-flex border rounded-md overflow-hidden">
+                      <button
+                        onClick={() => setEditorMode("form")}
+                        className={`px-3 py-1 text-sm ${editorMode === "form" ? "bg-stone-900 text-white" : "bg-white"}`}
+                      >
+                        Formulario
+                      </button>
+                      <button
+                        onClick={() => setEditorMode("json")}
+                        className={`px-3 py-1 text-sm ${editorMode === "json" ? "bg-stone-900 text-white" : "bg-white"}`}
+                      >
+                        JSON
+                      </button>
+                    </div>
+                  </div>
+                  {editorMode === "json" ? (
+                    <textarea
+                      value={rawJson}
+                      onChange={(e) => setRawJson(e.target.value)}
+                      className="w-full h-[460px] border rounded-md p-3 font-mono text-sm"
+                    />
+                  ) : (
+                    <div className="w-full h-[460px] border rounded-md bg-gray-50 overflow-auto">
+                      <JsonFormEditor
+                        jsonText={rawJson}
+                        onChangeJsonText={setRawJson}
+                      />
+                    </div>
+                  )}
+                  <div className="mt-3 flex gap-2">
+                    <button
+                      disabled={saving}
+                      onClick={handleSaveContent}
+                      className="px-4 py-2 bg-stone-900 text-white rounded-md"
+                    >
+                      Guardar
+                    </button>
+                  </div>
+                </>
               )}
-              <div className="mt-3 flex gap-2">
-                <button
-                  disabled={saving}
-                  onClick={handleSaveContent}
-                  className="px-4 py-2 bg-stone-900 text-white rounded-md"
-                >
-                  Guardar
-                </button>
-              </div>
             </div>
           </div>
         </section>

--- a/client/pages/Admin.tsx
+++ b/client/pages/Admin.tsx
@@ -216,6 +216,8 @@ export default function Admin() {
         ok: true,
         environment: result.environment,
         locales: result.locales,
+        warnings: result.warnings,
+        structured: result.structured,
       });
 
       await loadSettings();

--- a/client/pages/Admin.tsx
+++ b/client/pages/Admin.tsx
@@ -47,7 +47,13 @@ export default function Admin() {
 
   const [seeding, setSeeding] = useState(false);
   const [seedStatus, setSeedStatus] = useState<
-    { ok: true; environment: string; locales: { defaultLocale: string; es: string; en: string } } | null
+    {
+      ok: true;
+      environment: string;
+      locales: { defaultLocale: string; es: string; en: string };
+      warnings?: string[];
+      structured?: { stylesEnabled?: boolean };
+    } | null
   >(null);
 
   // styles: general theme
@@ -581,6 +587,19 @@ export default function Admin() {
               <div className="text-xs text-gray-500">
                 Environment: {seedStatus.environment} · Locales: ES={seedStatus.locales.es}, EN={seedStatus.locales.en}
               </div>
+              {seedStatus.structured?.stylesEnabled === false && (
+                <div className="mt-2 text-xs text-amber-700">
+                  Nota: no se pudieron crear los <span className="font-medium">estilos estructurados</span> en Contentful (falta permiso).
+                  La web seguirá usando estilos legacy.
+                </div>
+              )}
+              {seedStatus.warnings && seedStatus.warnings.length > 0 && (
+                <ul className="mt-2 text-xs text-amber-700 list-disc pl-5 space-y-1">
+                  {seedStatus.warnings.map((w) => (
+                    <li key={w}>{w}</li>
+                  ))}
+                </ul>
+              )}
             </div>
           )}
           {/* <div className="grid grid-cols-1 md:grid-cols-2 gap-6"> */}

--- a/client/pages/Admin.tsx
+++ b/client/pages/Admin.tsx
@@ -870,60 +870,90 @@ export default function Admin() {
 
       {tab === "styles" && selectedStyleKey !== "luminous.styles.generales" && (
         <section className="space-y-4 bg-white rounded-xl border shadow-sm p-4">
-          <div className="flex items-center justify-between mb-1">
-            <label className="block text-sm font-medium">
-              Editor de estilos ({locale})
-            </label>
-            <div className="inline-flex border rounded-md overflow-hidden">
-              <button
-                onClick={() => setStyleEditorMode("form")}
-                className={`px-3 py-1 text-sm ${styleEditorMode === "form" ? "bg-stone-900 text-white" : "bg-white"}`}
-              >
-                Formulario
-              </button>
-              <button
-                onClick={() => setStyleEditorMode("json")}
-                className={`px-3 py-1 text-sm ${styleEditorMode === "json" ? "bg-stone-900 text-white" : "bg-white"}`}
-              >
-                JSON
-              </button>
-            </div>
-          </div>
-          {styleEditorMode === "json" ? (
-            <textarea
-              value={styleRawJson}
-              onChange={(e) => setStyleRawJson(e.target.value)}
-              className="w-full h-[460px] border rounded-md p-3 font-mono text-sm"
-            />
+          {contentfulReadOnly ? (
+            <>
+              <div className="rounded-md border bg-amber-50 p-3 text-sm text-amber-900">
+                <div className="font-medium">Estilos administrados en Contentful</div>
+                <div className="text-xs text-amber-800">
+                  Este editor queda en <span className="font-medium">modo lectura</span>. Ajusta CSS/estilos desde Contentful.
+                </div>
+              </div>
+              <label className="block text-sm font-medium">
+                Estilos (solo lectura · {locale})
+              </label>
+              <div className="w-full h-[460px] border rounded-md bg-gray-50 overflow-auto">
+                <pre className="p-3 text-xs whitespace-pre-wrap font-mono">
+                  {styleRawJson}
+                </pre>
+              </div>
+              <div className="mt-3">
+                <button
+                  type="button"
+                  onClick={() => copyToClipboard(styleRawJson)}
+                  className="px-4 py-2 border rounded-md text-sm bg-white hover:bg-gray-50"
+                >
+                  Copiar JSON
+                </button>
+              </div>
+            </>
           ) : (
-            <div className="w-full h-[460px] border rounded-md bg-gray-50 overflow-auto">
-              <JsonFormEditor
-                jsonText={styleRawJson}
-                onChangeJsonText={setStyleRawJson}
-              />
-            </div>
+            <>
+              <div className="flex items-center justify-between mb-1">
+                <label className="block text-sm font-medium">
+                  Editor de estilos ({locale})
+                </label>
+                <div className="inline-flex border rounded-md overflow-hidden">
+                  <button
+                    onClick={() => setStyleEditorMode("form")}
+                    className={`px-3 py-1 text-sm ${styleEditorMode === "form" ? "bg-stone-900 text-white" : "bg-white"}`}
+                  >
+                    Formulario
+                  </button>
+                  <button
+                    onClick={() => setStyleEditorMode("json")}
+                    className={`px-3 py-1 text-sm ${styleEditorMode === "json" ? "bg-stone-900 text-white" : "bg-white"}`}
+                  >
+                    JSON
+                  </button>
+                </div>
+              </div>
+              {styleEditorMode === "json" ? (
+                <textarea
+                  value={styleRawJson}
+                  onChange={(e) => setStyleRawJson(e.target.value)}
+                  className="w-full h-[460px] border rounded-md p-3 font-mono text-sm"
+                />
+              ) : (
+                <div className="w-full h-[460px] border rounded-md bg-gray-50 overflow-auto">
+                  <JsonFormEditor
+                    jsonText={styleRawJson}
+                    onChangeJsonText={setStyleRawJson}
+                  />
+                </div>
+              )}
+              <div className="mt-3">
+                <button
+                  disabled={styleSaving}
+                  onClick={async () => {
+                    try {
+                      setStyleSaving(true);
+                      const parsed = JSON.parse(styleRawJson);
+                      await upsertContent(selectedStyleKey, locale, parsed);
+                      setStyleJson(parsed);
+                      alert("Estilos guardados");
+                    } catch (e: any) {
+                      alert("Error al guardar: " + e.message);
+                    } finally {
+                      setStyleSaving(false);
+                    }
+                  }}
+                  className="px-4 py-2 bg-stone-900 text-white rounded-md"
+                >
+                  Guardar
+                </button>
+              </div>
+            </>
           )}
-          <div className="mt-3">
-            <button
-              disabled={styleSaving}
-              onClick={async () => {
-                try {
-                  setStyleSaving(true);
-                  const parsed = JSON.parse(styleRawJson);
-                  await upsertContent(selectedStyleKey, locale, parsed);
-                  setStyleJson(parsed);
-                  alert("Estilos guardados");
-                } catch (e: any) {
-                  alert("Error al guardar: " + e.message);
-                } finally {
-                  setStyleSaving(false);
-                }
-              }}
-              className="px-4 py-2 bg-stone-900 text-white rounded-md"
-            >
-              Guardar
-            </button>
-          </div>
         </section>
       )}
 

--- a/server/contentful-seed.ts
+++ b/server/contentful-seed.ts
@@ -144,6 +144,118 @@ async function ensureContentType(envApi: any, id: string, spec: any) {
   await created.publish();
 }
 
+function guessImageContentType(url: string) {
+  const u = String(url || "").toLowerCase();
+  if (u.includes(".png")) return "image/png";
+  if (u.includes(".webp")) return "image/webp";
+  if (u.includes(".avif")) return "image/avif";
+  if (u.includes(".gif")) return "image/gif";
+  return "image/jpeg";
+}
+
+function guessImageFileExtension(url: string) {
+  const u = String(url || "").toLowerCase();
+  if (u.includes(".png")) return "png";
+  if (u.includes(".webp")) return "webp";
+  if (u.includes(".avif")) return "avif";
+  if (u.includes(".gif")) return "gif";
+  return "jpg";
+}
+
+async function ensureAssetFromUrl(envApi: any, defaultLocale: string, title: string, url: string) {
+  const safeTitle = title.trim();
+  if (!safeTitle) throw new Error("Missing asset title");
+  if (!url) throw new Error(`Missing asset url for ${safeTitle}`);
+
+  try {
+    const existing = await envApi.getAssets({
+      limit: 1,
+      "fields.title": safeTitle,
+    });
+    if (existing?.items?.length) {
+      return existing.items[0];
+    }
+  } catch {
+    // ignore search errors
+  }
+
+  const fileName = `${safeTitle}.${guessImageFileExtension(url)}`;
+
+  const asset = await envApi.createAsset({
+    fields: {
+      title: { [defaultLocale]: safeTitle },
+      file: {
+        [defaultLocale]: {
+          contentType: guessImageContentType(url),
+          fileName,
+          upload: url,
+        },
+      },
+    },
+  });
+
+  const processed = await asset.processForAllLocales();
+
+  // Processing is async in Contentful. We retry a few times until the file URL appears.
+  let ready = processed;
+  for (let i = 0; i < 10; i++) {
+    const reloaded = await ready.reload();
+    const file = reloaded?.fields?.file?.[defaultLocale];
+    if (file?.url) {
+      ready = reloaded;
+      break;
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+    ready = reloaded;
+  }
+
+  try {
+    await ready.publish();
+  } catch {
+    // ignore publish errors (e.g., already published)
+  }
+
+  return ready;
+}
+
+function linkToAsset(asset: any) {
+  return { sys: { type: "Link", linkType: "Asset", id: asset.sys.id } };
+}
+
+function linkToEntry(entry: any) {
+  return { sys: { type: "Link", linkType: "Entry", id: entry.sys.id } };
+}
+
+async function findEntryByKey(envApi: any, contentType: string, key: string) {
+  const q: Record<string, any> = { content_type: contentType, limit: 1 };
+  q["fields.key"] = key;
+  const res: any = await envApi.getEntries(q);
+  return (res?.items && res.items[0]) || null;
+}
+
+async function upsertEntryByKey(envApi: any, contentType: string, key: string, fields: any) {
+  const existing = await findEntryByKey(envApi, contentType, key);
+
+  if (existing) {
+    existing.fields = { ...existing.fields, ...fields };
+    const updated = await existing.update();
+    try {
+      await updated.publish();
+    } catch {
+      // ignore
+    }
+    return updated;
+  }
+
+  const created = await envApi.createEntry(contentType, { fields });
+  try {
+    await created.publish();
+  } catch {
+    // ignore
+  }
+  return created;
+}
+
 export async function seedContentfulFromDefaults() {
   const spaceId = requireEnv("CONTENTFUL_SPACE_ID");
   const managementToken = requireEnv("CONTENTFUL_MANAGEMENT_TOKEN");

--- a/server/contentful-seed.ts
+++ b/server/contentful-seed.ts
@@ -196,23 +196,14 @@ async function ensureAssetFromUrl(envApi: any, defaultLocale: string, title: str
 
   const processed = await asset.processForAllLocales();
 
-  // Processing is async in Contentful. We retry a few times until the file URL appears.
-  let ready = processed;
-  for (let i = 0; i < 10; i++) {
-    const reloaded = await ready.reload();
-    const file = reloaded?.fields?.file?.[defaultLocale];
-    if (file?.url) {
-      ready = reloaded;
-      break;
-    }
-    await new Promise((r) => setTimeout(r, 1000));
-    ready = reloaded;
-  }
+  // Processing is async in Contentful; avoid long waits so the seed finishes quickly.
+  // The asset can still finish processing shortly after.
+  const ready = await processed.reload();
 
   try {
     await ready.publish();
   } catch {
-    // ignore publish errors (e.g., already published)
+    // ignore publish errors (e.g. processing not done yet)
   }
 
   return ready;

--- a/server/contentful-seed.ts
+++ b/server/contentful-seed.ts
@@ -443,8 +443,9 @@ export async function seedContentfulFromDefaults() {
   await runStep("ensureContentType:dbtSpacesItem", async () =>
     ensureContentType(envApi, "dbtSpacesItem", {
       name: "DBT Spaces Item",
-      displayField: "title",
+      displayField: "key",
       fields: [
+        { id: "key", name: "Key", type: "Symbol", required: true, localized: false },
         { id: "title", name: "Title", type: "Symbol", required: false, localized: true },
         { id: "href", name: "Href", type: "Symbol", required: false, localized: true },
         {
@@ -486,8 +487,9 @@ export async function seedContentfulFromDefaults() {
   await runStep("ensureContentType:dbtTherapiesItem", async () =>
     ensureContentType(envApi, "dbtTherapiesItem", {
       name: "DBT Therapy Item",
-      displayField: "title",
+      displayField: "key",
       fields: [
+        { id: "key", name: "Key", type: "Symbol", required: true, localized: false },
         { id: "title", name: "Title", type: "Symbol", required: false, localized: true },
         { id: "desc", name: "Description", type: "Text", required: false, localized: true },
         {
@@ -528,8 +530,9 @@ export async function seedContentfulFromDefaults() {
   await runStep("ensureContentType:dbtServicesItem", async () =>
     ensureContentType(envApi, "dbtServicesItem", {
       name: "DBT Services Item",
-      displayField: "title",
+      displayField: "key",
       fields: [
+        { id: "key", name: "Key", type: "Symbol", required: true, localized: false },
         { id: "title", name: "Title", type: "Symbol", required: false, localized: true },
         { id: "desc", name: "Description", type: "Text", required: false, localized: true },
         {
@@ -571,8 +574,9 @@ export async function seedContentfulFromDefaults() {
   await runStep("ensureContentType:dbtProcessStep", async () =>
     ensureContentType(envApi, "dbtProcessStep", {
       name: "DBT Process Step",
-      displayField: "title",
+      displayField: "key",
       fields: [
+        { id: "key", name: "Key", type: "Symbol", required: true, localized: false },
         { id: "number", name: "Number", type: "Symbol", required: false, localized: true },
         { id: "title", name: "Title", type: "Symbol", required: false, localized: true },
         { id: "description", name: "Description", type: "Text", required: false, localized: true },
@@ -607,8 +611,9 @@ export async function seedContentfulFromDefaults() {
   await runStep("ensureContentType:dbtTeamMember", async () =>
     ensureContentType(envApi, "dbtTeamMember", {
       name: "DBT Team Member",
-      displayField: "name",
+      displayField: "key",
       fields: [
+        { id: "key", name: "Key", type: "Symbol", required: true, localized: false },
         { id: "name", name: "Name", type: "Symbol", required: false, localized: true },
         { id: "description", name: "Description", type: "Text", required: false, localized: true },
         {

--- a/server/contentful-seed.ts
+++ b/server/contentful-seed.ts
@@ -720,7 +720,79 @@ export async function seedContentfulFromDefaults() {
     }),
   );
 
-  // Styles types (optional). If the Contentful user doesn't have "content model" permissions,
+  // Unified styles: put section styles into the same section entry (e.g. DBT About + DBT Styles About).
+  // This requires content model permissions because we need to add fields to existing content types.
+  const nonLocalized = (value: any) => ({ [defaultLocale]: value });
+
+  const unifiedStyleFieldDefsByContentType: Record<string, any[]> = {
+    dbtHeader: [
+      { id: "title1Color", name: "Title 1 Color", type: "Symbol", required: false, localized: false },
+      { id: "title2Color", name: "Title 2 Color", type: "Symbol", required: false, localized: false },
+      { id: "title1Size", name: "Title 1 Size", type: "Number", required: false, localized: false },
+      { id: "title2Size", name: "Title 2 Size", type: "Number", required: false, localized: false },
+      { id: "subtitle1Color", name: "Subtitle 1 Color", type: "Symbol", required: false, localized: false },
+      { id: "subtitle2Color", name: "Subtitle 2 Color", type: "Symbol", required: false, localized: false },
+    ],
+    dbtAbout: [
+      { id: "titleColor", name: "Title Color", type: "Symbol", required: false, localized: false },
+      { id: "bodyColor", name: "Body Color", type: "Symbol", required: false, localized: false },
+      { id: "backgroundColor", name: "Background Color", type: "Symbol", required: false, localized: false },
+      { id: "titleSize", name: "Title Size", type: "Number", required: false, localized: false },
+      { id: "bodySize", name: "Body Size", type: "Number", required: false, localized: false },
+      {
+        id: "backgroundImage",
+        name: "Background Image",
+        type: "Link",
+        linkType: "Asset",
+        required: false,
+        localized: false,
+      },
+    ],
+    dbtSpaces: [
+      { id: "textColor", name: "Text Color", type: "Symbol", required: false, localized: false },
+      { id: "speedSeconds", name: "Speed Seconds", type: "Number", required: false, localized: false },
+    ],
+    dbtTherapies: [
+      { id: "titleColor", name: "Title Color", type: "Symbol", required: false, localized: false },
+      { id: "itemTitleColor", name: "Item Title Color", type: "Symbol", required: false, localized: false },
+      { id: "itemDescColor", name: "Item Desc Color", type: "Symbol", required: false, localized: false },
+    ],
+    dbtServices: [
+      { id: "titleColor", name: "Title Color", type: "Symbol", required: false, localized: false },
+      { id: "subtitleColor", name: "Subtitle Color", type: "Symbol", required: false, localized: false },
+      { id: "itemTitleColor", name: "Item Title Color", type: "Symbol", required: false, localized: false },
+    ],
+    dbtProcess: [
+      { id: "titleColor", name: "Title Color", type: "Symbol", required: false, localized: false },
+      { id: "introColor", name: "Intro Color", type: "Symbol", required: false, localized: false },
+      { id: "stepTitleColor", name: "Step Title Color", type: "Symbol", required: false, localized: false },
+      { id: "stepDescColor", name: "Step Desc Color", type: "Symbol", required: false, localized: false },
+    ],
+    dbtTeam: [
+      { id: "titleColor", name: "Title Color", type: "Symbol", required: false, localized: false },
+      { id: "nameColor", name: "Name Color", type: "Symbol", required: false, localized: false },
+      { id: "roleColor", name: "Role Color", type: "Symbol", required: false, localized: false },
+    ],
+    dbtContact: [
+      { id: "titleColor", name: "Title Color", type: "Symbol", required: false, localized: false },
+      { id: "infoColor", name: "Info Color", type: "Symbol", required: false, localized: false },
+    ],
+    dbtFooter: [
+      { id: "textColor", name: "Text Color", type: "Symbol", required: false, localized: false },
+    ],
+  };
+
+  const unifiedStylesEnabledByContentType: Record<string, boolean> = {};
+  for (const [contentTypeId, fields] of Object.entries(unifiedStyleFieldDefsByContentType)) {
+    const ok = await runOptionalStep(`extendContentType:${contentTypeId}:styles`, async () =>
+      ensureContentTypeHasFields(envApi, contentTypeId, fields),
+    );
+    unifiedStylesEnabledByContentType[contentTypeId] = ok;
+  }
+
+  const unifiedStylesEnabled = Object.values(unifiedStylesEnabledByContentType).some(Boolean);
+
+  // Styles types (legacy / optional). If the Contentful user doesn't have "content model" permissions,
   // we skip these and the site keeps using the legacy JSON styles.
   let structuredStylesEnabled = true;
 

--- a/server/contentful-seed.ts
+++ b/server/contentful-seed.ts
@@ -375,6 +375,451 @@ export async function seedContentfulFromDefaults() {
     }),
   );
 
+  // Structured types for managing content directly in Contentful (field editors + asset uploads)
+  await runStep("ensureContentType:dbtSeo", async () =>
+    ensureContentType(envApi, "dbtSeo", {
+      name: "DBT SEO",
+      displayField: "key",
+      fields: [
+        { id: "key", name: "Key", type: "Symbol", required: true, localized: false },
+        { id: "title", name: "Title", type: "Symbol", required: false, localized: true },
+        { id: "description", name: "Description", type: "Text", required: false, localized: true },
+        { id: "canonical", name: "Canonical", type: "Symbol", required: false, localized: true },
+        { id: "ogUrl", name: "OG Url", type: "Symbol", required: false, localized: true },
+        { id: "ogImage", name: "OG Image", type: "Symbol", required: false, localized: true },
+        { id: "keywords", name: "Keywords", type: "Text", required: false, localized: true },
+      ],
+    }),
+  );
+
+  await runStep("ensureContentType:dbtHeader", async () =>
+    ensureContentType(envApi, "dbtHeader", {
+      name: "DBT Header",
+      displayField: "key",
+      fields: [
+        { id: "key", name: "Key", type: "Symbol", required: true, localized: false },
+        { id: "title1", name: "Title 1", type: "Symbol", required: false, localized: true },
+        { id: "title2", name: "Title 2", type: "Symbol", required: false, localized: true },
+        { id: "subtitle1", name: "Subtitle 1", type: "Text", required: false, localized: true },
+        { id: "subtitle2", name: "Subtitle 2", type: "Text", required: false, localized: true },
+        { id: "cta1", name: "CTA 1", type: "Symbol", required: false, localized: true },
+        { id: "cta1Link", name: "CTA 1 Link", type: "Symbol", required: false, localized: true },
+        { id: "cta2", name: "CTA 2", type: "Symbol", required: false, localized: true },
+        { id: "cta2Link", name: "CTA 2 Link", type: "Symbol", required: false, localized: true },
+        {
+          id: "backgroundImage",
+          name: "Background Image",
+          type: "Link",
+          linkType: "Asset",
+          required: false,
+          localized: false,
+        },
+      ],
+    }),
+  );
+
+  await runStep("ensureContentType:dbtAbout", async () =>
+    ensureContentType(envApi, "dbtAbout", {
+      name: "DBT About",
+      displayField: "key",
+      fields: [
+        { id: "key", name: "Key", type: "Symbol", required: true, localized: false },
+        { id: "title", name: "Title", type: "Symbol", required: false, localized: true },
+        { id: "body", name: "Body", type: "Text", required: false, localized: true },
+        { id: "linkText", name: "Link Text", type: "Symbol", required: false, localized: true },
+        { id: "linkUrl", name: "Link Url", type: "Symbol", required: false, localized: true },
+        {
+          id: "image",
+          name: "Image",
+          type: "Link",
+          linkType: "Asset",
+          required: false,
+          localized: false,
+        },
+      ],
+    }),
+  );
+
+  await runStep("ensureContentType:dbtSpacesItem", async () =>
+    ensureContentType(envApi, "dbtSpacesItem", {
+      name: "DBT Spaces Item",
+      displayField: "title",
+      fields: [
+        { id: "title", name: "Title", type: "Symbol", required: false, localized: true },
+        { id: "href", name: "Href", type: "Symbol", required: false, localized: true },
+        {
+          id: "image",
+          name: "Image",
+          type: "Link",
+          linkType: "Asset",
+          required: false,
+          localized: false,
+        },
+      ],
+    }),
+  );
+
+  await runStep("ensureContentType:dbtSpaces", async () =>
+    ensureContentType(envApi, "dbtSpaces", {
+      name: "DBT Spaces",
+      displayField: "key",
+      fields: [
+        { id: "key", name: "Key", type: "Symbol", required: true, localized: false },
+        { id: "eyebrow", name: "Eyebrow", type: "Symbol", required: false, localized: true },
+        { id: "title", name: "Title", type: "Symbol", required: false, localized: true },
+        {
+          id: "items",
+          name: "Items",
+          type: "Array",
+          required: false,
+          localized: false,
+          items: {
+            type: "Link",
+            linkType: "Entry",
+            validations: [{ linkContentType: ["dbtSpacesItem"] }],
+          },
+        },
+      ],
+    }),
+  );
+
+  await runStep("ensureContentType:dbtTherapiesItem", async () =>
+    ensureContentType(envApi, "dbtTherapiesItem", {
+      name: "DBT Therapy Item",
+      displayField: "title",
+      fields: [
+        { id: "title", name: "Title", type: "Symbol", required: false, localized: true },
+        { id: "desc", name: "Description", type: "Text", required: false, localized: true },
+        {
+          id: "image",
+          name: "Image",
+          type: "Link",
+          linkType: "Asset",
+          required: false,
+          localized: false,
+        },
+      ],
+    }),
+  );
+
+  await runStep("ensureContentType:dbtTherapies", async () =>
+    ensureContentType(envApi, "dbtTherapies", {
+      name: "DBT Therapies",
+      displayField: "key",
+      fields: [
+        { id: "key", name: "Key", type: "Symbol", required: true, localized: false },
+        { id: "title", name: "Title", type: "Symbol", required: false, localized: true },
+        {
+          id: "items",
+          name: "Items",
+          type: "Array",
+          required: false,
+          localized: false,
+          items: {
+            type: "Link",
+            linkType: "Entry",
+            validations: [{ linkContentType: ["dbtTherapiesItem"] }],
+          },
+        },
+      ],
+    }),
+  );
+
+  await runStep("ensureContentType:dbtServicesItem", async () =>
+    ensureContentType(envApi, "dbtServicesItem", {
+      name: "DBT Services Item",
+      displayField: "title",
+      fields: [
+        { id: "title", name: "Title", type: "Symbol", required: false, localized: true },
+        { id: "desc", name: "Description", type: "Text", required: false, localized: true },
+        {
+          id: "image",
+          name: "Image",
+          type: "Link",
+          linkType: "Asset",
+          required: false,
+          localized: false,
+        },
+      ],
+    }),
+  );
+
+  await runStep("ensureContentType:dbtServices", async () =>
+    ensureContentType(envApi, "dbtServices", {
+      name: "DBT Services",
+      displayField: "key",
+      fields: [
+        { id: "key", name: "Key", type: "Symbol", required: true, localized: false },
+        { id: "title", name: "Title", type: "Symbol", required: false, localized: true },
+        { id: "subtitle", name: "Subtitle", type: "Text", required: false, localized: true },
+        {
+          id: "items",
+          name: "Items",
+          type: "Array",
+          required: false,
+          localized: false,
+          items: {
+            type: "Link",
+            linkType: "Entry",
+            validations: [{ linkContentType: ["dbtServicesItem"] }],
+          },
+        },
+      ],
+    }),
+  );
+
+  await runStep("ensureContentType:dbtProcessStep", async () =>
+    ensureContentType(envApi, "dbtProcessStep", {
+      name: "DBT Process Step",
+      displayField: "title",
+      fields: [
+        { id: "number", name: "Number", type: "Symbol", required: false, localized: true },
+        { id: "title", name: "Title", type: "Symbol", required: false, localized: true },
+        { id: "description", name: "Description", type: "Text", required: false, localized: true },
+      ],
+    }),
+  );
+
+  await runStep("ensureContentType:dbtProcess", async () =>
+    ensureContentType(envApi, "dbtProcess", {
+      name: "DBT Process",
+      displayField: "key",
+      fields: [
+        { id: "key", name: "Key", type: "Symbol", required: true, localized: false },
+        { id: "title", name: "Title", type: "Symbol", required: false, localized: true },
+        { id: "intro", name: "Intro", type: "Text", required: false, localized: true },
+        {
+          id: "steps",
+          name: "Steps",
+          type: "Array",
+          required: false,
+          localized: false,
+          items: {
+            type: "Link",
+            linkType: "Entry",
+            validations: [{ linkContentType: ["dbtProcessStep"] }],
+          },
+        },
+      ],
+    }),
+  );
+
+  await runStep("ensureContentType:dbtTeamMember", async () =>
+    ensureContentType(envApi, "dbtTeamMember", {
+      name: "DBT Team Member",
+      displayField: "name",
+      fields: [
+        { id: "name", name: "Name", type: "Symbol", required: false, localized: true },
+        { id: "description", name: "Description", type: "Text", required: false, localized: true },
+        {
+          id: "image",
+          name: "Image",
+          type: "Link",
+          linkType: "Asset",
+          required: false,
+          localized: false,
+        },
+        {
+          id: "specialties",
+          name: "Specialties",
+          type: "Array",
+          required: false,
+          localized: true,
+          items: { type: "Symbol" },
+        },
+      ],
+    }),
+  );
+
+  await runStep("ensureContentType:dbtTeam", async () =>
+    ensureContentType(envApi, "dbtTeam", {
+      name: "DBT Team",
+      displayField: "key",
+      fields: [
+        { id: "key", name: "Key", type: "Symbol", required: true, localized: false },
+        { id: "title", name: "Title", type: "Symbol", required: false, localized: true },
+        {
+          id: "members",
+          name: "Members",
+          type: "Array",
+          required: false,
+          localized: false,
+          items: {
+            type: "Link",
+            linkType: "Entry",
+            validations: [{ linkContentType: ["dbtTeamMember"] }],
+          },
+        },
+      ],
+    }),
+  );
+
+  await runStep("ensureContentType:dbtContact", async () =>
+    ensureContentType(envApi, "dbtContact", {
+      name: "DBT Contact",
+      displayField: "key",
+      fields: [
+        { id: "key", name: "Key", type: "Symbol", required: true, localized: false },
+        { id: "title", name: "Title", type: "Symbol", required: false, localized: true },
+        { id: "address", name: "Address", type: "Text", required: false, localized: true },
+        { id: "whatsapp", name: "WhatsApp", type: "Symbol", required: false, localized: true },
+        { id: "instagram", name: "Instagram", type: "Symbol", required: false, localized: true },
+        { id: "email", name: "Email", type: "Symbol", required: false, localized: true },
+        { id: "hoursWeekdays", name: "Hours Weekdays", type: "Symbol", required: false, localized: true },
+        { id: "hoursSaturday", name: "Hours Saturday", type: "Symbol", required: false, localized: true },
+        { id: "hoursSunday", name: "Hours Sunday", type: "Symbol", required: false, localized: true },
+      ],
+    }),
+  );
+
+  await runStep("ensureContentType:dbtFooter", async () =>
+    ensureContentType(envApi, "dbtFooter", {
+      name: "DBT Footer",
+      displayField: "key",
+      fields: [
+        { id: "key", name: "Key", type: "Symbol", required: true, localized: false },
+        { id: "quote", name: "Quote", type: "Text", required: false, localized: true },
+        { id: "text", name: "Text", type: "Symbol", required: false, localized: true },
+      ],
+    }),
+  );
+
+  // Styles types (optional but enables editing style values as fields)
+  await runStep("ensureContentType:dbtStylesGenerales", async () =>
+    ensureContentType(envApi, "dbtStylesGenerales", {
+      name: "DBT Styles Generales",
+      displayField: "key",
+      fields: [
+        { id: "key", name: "Key", type: "Symbol", required: true, localized: false },
+        { id: "primary", name: "Primary", type: "Symbol", required: false, localized: false },
+        { id: "secondary", name: "Secondary", type: "Symbol", required: false, localized: false },
+        { id: "fontFamily", name: "Font Family", type: "Symbol", required: false, localized: false },
+        { id: "baseSize", name: "Base Size", type: "Number", required: false, localized: false },
+        { id: "logoUrl", name: "Logo URL", type: "Symbol", required: false, localized: false },
+      ],
+    }),
+  );
+
+  await runStep("ensureContentType:dbtStylesHeader", async () =>
+    ensureContentType(envApi, "dbtStylesHeader", {
+      name: "DBT Styles Header",
+      displayField: "key",
+      fields: [
+        { id: "key", name: "Key", type: "Symbol", required: true, localized: false },
+        { id: "title1Color", name: "Title 1 Color", type: "Symbol", required: false, localized: false },
+        { id: "title2Color", name: "Title 2 Color", type: "Symbol", required: false, localized: false },
+        { id: "title1Size", name: "Title 1 Size", type: "Number", required: false, localized: false },
+        { id: "title2Size", name: "Title 2 Size", type: "Number", required: false, localized: false },
+        { id: "subtitle1Color", name: "Subtitle 1 Color", type: "Symbol", required: false, localized: false },
+        { id: "subtitle2Color", name: "Subtitle 2 Color", type: "Symbol", required: false, localized: false },
+      ],
+    }),
+  );
+
+  await runStep("ensureContentType:dbtStylesAbout", async () =>
+    ensureContentType(envApi, "dbtStylesAbout", {
+      name: "DBT Styles About",
+      displayField: "key",
+      fields: [
+        { id: "key", name: "Key", type: "Symbol", required: true, localized: false },
+        { id: "titleColor", name: "Title Color", type: "Symbol", required: false, localized: false },
+        { id: "bodyColor", name: "Body Color", type: "Symbol", required: false, localized: false },
+        { id: "backgroundColor", name: "Background Color", type: "Symbol", required: false, localized: false },
+        { id: "titleSize", name: "Title Size", type: "Number", required: false, localized: false },
+        { id: "bodySize", name: "Body Size", type: "Number", required: false, localized: false },
+        { id: "backgroundImage", name: "Background Image", type: "Symbol", required: false, localized: false },
+      ],
+    }),
+  );
+
+  await runStep("ensureContentType:dbtStylesSpaces", async () =>
+    ensureContentType(envApi, "dbtStylesSpaces", {
+      name: "DBT Styles Spaces",
+      displayField: "key",
+      fields: [
+        { id: "key", name: "Key", type: "Symbol", required: true, localized: false },
+        { id: "textColor", name: "Text Color", type: "Symbol", required: false, localized: false },
+        { id: "speedSeconds", name: "Speed Seconds", type: "Number", required: false, localized: false },
+      ],
+    }),
+  );
+
+  await runStep("ensureContentType:dbtStylesTherapies", async () =>
+    ensureContentType(envApi, "dbtStylesTherapies", {
+      name: "DBT Styles Therapies",
+      displayField: "key",
+      fields: [
+        { id: "key", name: "Key", type: "Symbol", required: true, localized: false },
+        { id: "titleColor", name: "Title Color", type: "Symbol", required: false, localized: false },
+        { id: "itemTitleColor", name: "Item Title Color", type: "Symbol", required: false, localized: false },
+        { id: "itemDescColor", name: "Item Desc Color", type: "Symbol", required: false, localized: false },
+      ],
+    }),
+  );
+
+  await runStep("ensureContentType:dbtStylesServices", async () =>
+    ensureContentType(envApi, "dbtStylesServices", {
+      name: "DBT Styles Services",
+      displayField: "key",
+      fields: [
+        { id: "key", name: "Key", type: "Symbol", required: true, localized: false },
+        { id: "titleColor", name: "Title Color", type: "Symbol", required: false, localized: false },
+        { id: "subtitleColor", name: "Subtitle Color", type: "Symbol", required: false, localized: false },
+        { id: "itemTitleColor", name: "Item Title Color", type: "Symbol", required: false, localized: false },
+      ],
+    }),
+  );
+
+  await runStep("ensureContentType:dbtStylesProcess", async () =>
+    ensureContentType(envApi, "dbtStylesProcess", {
+      name: "DBT Styles Process",
+      displayField: "key",
+      fields: [
+        { id: "key", name: "Key", type: "Symbol", required: true, localized: false },
+        { id: "titleColor", name: "Title Color", type: "Symbol", required: false, localized: false },
+        { id: "introColor", name: "Intro Color", type: "Symbol", required: false, localized: false },
+        { id: "stepTitleColor", name: "Step Title Color", type: "Symbol", required: false, localized: false },
+        { id: "stepDescColor", name: "Step Desc Color", type: "Symbol", required: false, localized: false },
+      ],
+    }),
+  );
+
+  await runStep("ensureContentType:dbtStylesTeam", async () =>
+    ensureContentType(envApi, "dbtStylesTeam", {
+      name: "DBT Styles Team",
+      displayField: "key",
+      fields: [
+        { id: "key", name: "Key", type: "Symbol", required: true, localized: false },
+        { id: "titleColor", name: "Title Color", type: "Symbol", required: false, localized: false },
+        { id: "nameColor", name: "Name Color", type: "Symbol", required: false, localized: false },
+        { id: "roleColor", name: "Role Color", type: "Symbol", required: false, localized: false },
+      ],
+    }),
+  );
+
+  await runStep("ensureContentType:dbtStylesContact", async () =>
+    ensureContentType(envApi, "dbtStylesContact", {
+      name: "DBT Styles Contact",
+      displayField: "key",
+      fields: [
+        { id: "key", name: "Key", type: "Symbol", required: true, localized: false },
+        { id: "titleColor", name: "Title Color", type: "Symbol", required: false, localized: false },
+        { id: "infoColor", name: "Info Color", type: "Symbol", required: false, localized: false },
+      ],
+    }),
+  );
+
+  await runStep("ensureContentType:dbtStylesFooter", async () =>
+    ensureContentType(envApi, "dbtStylesFooter", {
+      name: "DBT Styles Footer",
+      displayField: "key",
+      fields: [
+        { id: "key", name: "Key", type: "Symbol", required: true, localized: false },
+        { id: "textColor", name: "Text Color", type: "Symbol", required: false, localized: false },
+      ],
+    }),
+  );
+
   const { contentfulUpsertContent, contentfulUpsertSiteSettings } =
     await import("./contentful-store");
 

--- a/server/contentful-seed.ts
+++ b/server/contentful-seed.ts
@@ -709,9 +709,14 @@ export async function seedContentfulFromDefaults() {
     }),
   );
 
-  // Styles types (optional but enables editing style values as fields)
-  await runStep("ensureContentType:dbtStylesGenerales", async () =>
-    ensureContentType(envApi, "dbtStylesGenerales", {
+  // Styles types (optional). If the Contentful user doesn't have "content model" permissions,
+  // we skip these and the site keeps using the legacy JSON styles.
+  let structuredStylesEnabled = true;
+
+  structuredStylesEnabled =
+    structuredStylesEnabled &&
+    (await runOptionalStep("ensureContentType:dbtStylesGenerales", async () =>
+      ensureContentType(envApi, "dbtStylesGenerales", {
       name: "DBT Styles Generales",
       displayField: "key",
       fields: [
@@ -722,11 +727,13 @@ export async function seedContentfulFromDefaults() {
         { id: "baseSize", name: "Base Size", type: "Number", required: false, localized: false },
         { id: "logoUrl", name: "Logo URL", type: "Symbol", required: false, localized: false },
       ],
-    }),
-  );
+      }),
+    ));
 
-  await runStep("ensureContentType:dbtStylesHeader", async () =>
-    ensureContentType(envApi, "dbtStylesHeader", {
+  structuredStylesEnabled =
+    structuredStylesEnabled &&
+    (await runOptionalStep("ensureContentType:dbtStylesHeader", async () =>
+      ensureContentType(envApi, "dbtStylesHeader", {
       name: "DBT Styles Header",
       displayField: "key",
       fields: [
@@ -738,11 +745,13 @@ export async function seedContentfulFromDefaults() {
         { id: "subtitle1Color", name: "Subtitle 1 Color", type: "Symbol", required: false, localized: false },
         { id: "subtitle2Color", name: "Subtitle 2 Color", type: "Symbol", required: false, localized: false },
       ],
-    }),
-  );
+      }),
+    ));
 
-  await runStep("ensureContentType:dbtStylesAbout", async () =>
-    ensureContentType(envApi, "dbtStylesAbout", {
+  structuredStylesEnabled =
+    structuredStylesEnabled &&
+    (await runOptionalStep("ensureContentType:dbtStylesAbout", async () =>
+      ensureContentType(envApi, "dbtStylesAbout", {
       name: "DBT Styles About",
       displayField: "key",
       fields: [
@@ -754,11 +763,13 @@ export async function seedContentfulFromDefaults() {
         { id: "bodySize", name: "Body Size", type: "Number", required: false, localized: false },
         { id: "backgroundImage", name: "Background Image", type: "Symbol", required: false, localized: false },
       ],
-    }),
-  );
+      }),
+    ));
 
-  await runStep("ensureContentType:dbtStylesSpaces", async () =>
-    ensureContentType(envApi, "dbtStylesSpaces", {
+  structuredStylesEnabled =
+    structuredStylesEnabled &&
+    (await runOptionalStep("ensureContentType:dbtStylesSpaces", async () =>
+      ensureContentType(envApi, "dbtStylesSpaces", {
       name: "DBT Styles Spaces",
       displayField: "key",
       fields: [
@@ -766,11 +777,13 @@ export async function seedContentfulFromDefaults() {
         { id: "textColor", name: "Text Color", type: "Symbol", required: false, localized: false },
         { id: "speedSeconds", name: "Speed Seconds", type: "Number", required: false, localized: false },
       ],
-    }),
-  );
+      }),
+    ));
 
-  await runStep("ensureContentType:dbtStylesTherapies", async () =>
-    ensureContentType(envApi, "dbtStylesTherapies", {
+  structuredStylesEnabled =
+    structuredStylesEnabled &&
+    (await runOptionalStep("ensureContentType:dbtStylesTherapies", async () =>
+      ensureContentType(envApi, "dbtStylesTherapies", {
       name: "DBT Styles Therapies",
       displayField: "key",
       fields: [
@@ -779,11 +792,13 @@ export async function seedContentfulFromDefaults() {
         { id: "itemTitleColor", name: "Item Title Color", type: "Symbol", required: false, localized: false },
         { id: "itemDescColor", name: "Item Desc Color", type: "Symbol", required: false, localized: false },
       ],
-    }),
-  );
+      }),
+    ));
 
-  await runStep("ensureContentType:dbtStylesServices", async () =>
-    ensureContentType(envApi, "dbtStylesServices", {
+  structuredStylesEnabled =
+    structuredStylesEnabled &&
+    (await runOptionalStep("ensureContentType:dbtStylesServices", async () =>
+      ensureContentType(envApi, "dbtStylesServices", {
       name: "DBT Styles Services",
       displayField: "key",
       fields: [
@@ -792,11 +807,13 @@ export async function seedContentfulFromDefaults() {
         { id: "subtitleColor", name: "Subtitle Color", type: "Symbol", required: false, localized: false },
         { id: "itemTitleColor", name: "Item Title Color", type: "Symbol", required: false, localized: false },
       ],
-    }),
-  );
+      }),
+    ));
 
-  await runStep("ensureContentType:dbtStylesProcess", async () =>
-    ensureContentType(envApi, "dbtStylesProcess", {
+  structuredStylesEnabled =
+    structuredStylesEnabled &&
+    (await runOptionalStep("ensureContentType:dbtStylesProcess", async () =>
+      ensureContentType(envApi, "dbtStylesProcess", {
       name: "DBT Styles Process",
       displayField: "key",
       fields: [
@@ -806,11 +823,13 @@ export async function seedContentfulFromDefaults() {
         { id: "stepTitleColor", name: "Step Title Color", type: "Symbol", required: false, localized: false },
         { id: "stepDescColor", name: "Step Desc Color", type: "Symbol", required: false, localized: false },
       ],
-    }),
-  );
+      }),
+    ));
 
-  await runStep("ensureContentType:dbtStylesTeam", async () =>
-    ensureContentType(envApi, "dbtStylesTeam", {
+  structuredStylesEnabled =
+    structuredStylesEnabled &&
+    (await runOptionalStep("ensureContentType:dbtStylesTeam", async () =>
+      ensureContentType(envApi, "dbtStylesTeam", {
       name: "DBT Styles Team",
       displayField: "key",
       fields: [
@@ -819,11 +838,13 @@ export async function seedContentfulFromDefaults() {
         { id: "nameColor", name: "Name Color", type: "Symbol", required: false, localized: false },
         { id: "roleColor", name: "Role Color", type: "Symbol", required: false, localized: false },
       ],
-    }),
-  );
+      }),
+    ));
 
-  await runStep("ensureContentType:dbtStylesContact", async () =>
-    ensureContentType(envApi, "dbtStylesContact", {
+  structuredStylesEnabled =
+    structuredStylesEnabled &&
+    (await runOptionalStep("ensureContentType:dbtStylesContact", async () =>
+      ensureContentType(envApi, "dbtStylesContact", {
       name: "DBT Styles Contact",
       displayField: "key",
       fields: [
@@ -831,19 +852,21 @@ export async function seedContentfulFromDefaults() {
         { id: "titleColor", name: "Title Color", type: "Symbol", required: false, localized: false },
         { id: "infoColor", name: "Info Color", type: "Symbol", required: false, localized: false },
       ],
-    }),
-  );
+      }),
+    ));
 
-  await runStep("ensureContentType:dbtStylesFooter", async () =>
-    ensureContentType(envApi, "dbtStylesFooter", {
+  structuredStylesEnabled =
+    structuredStylesEnabled &&
+    (await runOptionalStep("ensureContentType:dbtStylesFooter", async () =>
+      ensureContentType(envApi, "dbtStylesFooter", {
       name: "DBT Styles Footer",
       displayField: "key",
       fields: [
         { id: "key", name: "Key", type: "Symbol", required: true, localized: false },
         { id: "textColor", name: "Text Color", type: "Symbol", required: false, localized: false },
       ],
-    }),
-  );
+      }),
+    ));
 
   const { contentfulUpsertContent, contentfulUpsertSiteSettings } =
     await import("./contentful-store");

--- a/server/contentful-seed.ts
+++ b/server/contentful-seed.ts
@@ -144,6 +144,17 @@ async function ensureContentType(envApi: any, id: string, spec: any) {
   await created.publish();
 }
 
+async function ensureContentTypeHasFields(envApi: any, id: string, fields: any[]) {
+  const ct = await envApi.getContentType(id);
+  const existingIds = new Set<string>((ct?.fields || []).map((f: any) => String(f.id)));
+  const toAdd = fields.filter((f) => f?.id && !existingIds.has(String(f.id)));
+  if (!toAdd.length) return;
+
+  ct.fields = [...(ct.fields || []), ...toAdd];
+  const updated = await ct.update();
+  await updated.publish();
+}
+
 function guessImageContentType(url: string) {
   const u = String(url || "").toLowerCase();
   if (u.includes(".png")) return "image/png";

--- a/server/contentful-seed.ts
+++ b/server/contentful-seed.ts
@@ -1277,6 +1277,298 @@ export async function seedContentfulFromDefaults() {
 
   const localesToSeed: SeedLocale[] = ["es", "en"];
 
+  // Seed structured entries so Contentful can manage the site via field editors and Asset uploads.
+  // The frontend continues to support the legacy JSON entries as fallback.
+  const loc = (esValue: any, enValue: any) => {
+    const out: any = { [localeEs]: esValue, [localeEn]: enValue };
+    if (!(defaultLocale in out)) {
+      out[defaultLocale] = defaultLocale.toLowerCase().startsWith("es")
+        ? esValue
+        : enValue;
+    }
+    return out;
+  };
+
+  const makeKeyField = (k: string) => ({ [defaultLocale]: k });
+
+  const headerBgAsset = await runStep("asset:dbtHeaderBackground", async () =>
+    ensureAssetFromUrl(
+      envApi,
+      defaultLocale,
+      "dbt-header-background",
+      HEADER.es.backgroundImage,
+    ),
+  );
+
+  const aboutAsset = await runStep("asset:dbtAboutImage", async () =>
+    ensureAssetFromUrl(envApi, defaultLocale, "dbt-about-image", ABOUT.es.image),
+  );
+
+  // Spaces items
+  const spacesItemEntries: any[] = [];
+  for (let i = 0; i < (SPACES.es.items || []).length; i++) {
+    const key = `luminous.spaces.item.${i + 1}`;
+    const imageUrl = SPACES.es.items[i]?.image;
+
+    const asset = await runStep(`asset:dbtSpaces:${i + 1}`, async () =>
+      ensureAssetFromUrl(envApi, defaultLocale, `dbt-spaces-${i + 1}`, imageUrl),
+    );
+
+    const entry = await runStep(`entry:dbtSpacesItem:${i + 1}`, async () =>
+      upsertEntryByKey(envApi, "dbtSpacesItem", key, {
+        key: makeKeyField(key),
+        title: loc(SPACES.es.items[i]?.title || "", SPACES.en.items[i]?.title || ""),
+        href: loc(SPACES.es.items[i]?.href || "", SPACES.en.items[i]?.href || ""),
+        image: { [defaultLocale]: linkToAsset(asset) },
+      }),
+    );
+
+    spacesItemEntries.push(entry);
+  }
+
+  // Therapies items
+  const therapiesItemEntries: any[] = [];
+  for (let i = 0; i < (THERAPIES.es.items || []).length; i++) {
+    const key = `luminous.therapies.item.${i + 1}`;
+    const imageUrl = THERAPIES.es.items[i]?.image;
+
+    const asset = await runStep(`asset:dbtTherapies:${i + 1}`, async () =>
+      ensureAssetFromUrl(
+        envApi,
+        defaultLocale,
+        `dbt-therapy-${i + 1}`,
+        imageUrl,
+      ),
+    );
+
+    const entry = await runStep(`entry:dbtTherapiesItem:${i + 1}`, async () =>
+      upsertEntryByKey(envApi, "dbtTherapiesItem", key, {
+        key: makeKeyField(key),
+        title: loc(
+          THERAPIES.es.items[i]?.title || "",
+          THERAPIES.en.items[i]?.title || "",
+        ),
+        desc: loc(
+          THERAPIES.es.items[i]?.desc || "",
+          THERAPIES.en.items[i]?.desc || "",
+        ),
+        image: { [defaultLocale]: linkToAsset(asset) },
+      }),
+    );
+
+    therapiesItemEntries.push(entry);
+  }
+
+  // Services items (images are optional; the component has its own fallback images)
+  const servicesItemEntries: any[] = [];
+  for (let i = 0; i < (SERVICES.es.items || []).length; i++) {
+    const key = `luminous.services.item.${i + 1}`;
+    const entry = await runStep(`entry:dbtServicesItem:${i + 1}`, async () =>
+      upsertEntryByKey(envApi, "dbtServicesItem", key, {
+        key: makeKeyField(key),
+        title: loc(
+          SERVICES.es.items[i]?.title || "",
+          SERVICES.en.items[i]?.title || "",
+        ),
+        desc: loc(
+          SERVICES.es.items[i]?.desc || "",
+          SERVICES.en.items[i]?.desc || "",
+        ),
+      }),
+    );
+    servicesItemEntries.push(entry);
+  }
+
+  // Process steps
+  const processStepEntries: any[] = [];
+  for (let i = 0; i < (PROCESS.es.steps || []).length; i++) {
+    const key = `luminous.process.step.${i + 1}`;
+    const entry = await runStep(`entry:dbtProcessStep:${i + 1}`, async () =>
+      upsertEntryByKey(envApi, "dbtProcessStep", key, {
+        key: makeKeyField(key),
+        number: loc(`0${i + 1}`, `0${i + 1}`),
+        title: loc(
+          PROCESS.es.steps[i]?.title || "",
+          PROCESS.en.steps[i]?.title || "",
+        ),
+        description: loc(
+          PROCESS.es.steps[i]?.description || "",
+          PROCESS.en.steps[i]?.description || "",
+        ),
+      }),
+    );
+    processStepEntries.push(entry);
+  }
+
+  // Team members
+  const teamMemberEntries: any[] = [];
+  for (let i = 0; i < (TEAM.es.members || []).length; i++) {
+    const key = `luminous.team.member.${i + 1}`;
+    const imageUrl = TEAM.es.members[i]?.image;
+
+    const asset = await runStep(`asset:dbtTeam:${i + 1}`, async () =>
+      ensureAssetFromUrl(envApi, defaultLocale, `dbt-team-${i + 1}`, imageUrl),
+    );
+
+    const entry = await runStep(`entry:dbtTeamMember:${i + 1}`, async () =>
+      upsertEntryByKey(envApi, "dbtTeamMember", key, {
+        key: makeKeyField(key),
+        name: loc(TEAM.es.members[i]?.name || "", TEAM.en.members[i]?.name || ""),
+        description: loc(
+          TEAM.es.members[i]?.description || "",
+          TEAM.en.members[i]?.description || "",
+        ),
+        image: { [defaultLocale]: linkToAsset(asset) },
+        specialties: loc(
+          TEAM.es.members[i]?.specialties || [],
+          TEAM.en.members[i]?.specialties || [],
+        ),
+      }),
+    );
+
+    teamMemberEntries.push(entry);
+  }
+
+  // Section entries
+  await runStep("entry:dbtSeo", async () =>
+    upsertEntryByKey(envApi, "dbtSeo", "luminous.seo", {
+      key: makeKeyField("luminous.seo"),
+      title: loc(SEO.es.title, SEO.en.title),
+      description: loc(SEO.es.description, SEO.en.description),
+      canonical: loc(SEO.es.canonical, SEO.en.canonical),
+      ogUrl: loc(SEO.es.ogUrl, SEO.en.ogUrl),
+      ogImage: loc(SEO.es.ogImage, SEO.en.ogImage),
+      keywords: loc(SEO.es.keywords, SEO.en.keywords),
+    }),
+  );
+
+  await runStep("entry:dbtHeader", async () =>
+    upsertEntryByKey(envApi, "dbtHeader", "luminous.header", {
+      key: makeKeyField("luminous.header"),
+      title1: loc(HEADER.es.title1, HEADER.en.title1),
+      title2: loc(HEADER.es.title2, HEADER.en.title2),
+      subtitle1: loc(HEADER.es.subtitle1, HEADER.en.subtitle1),
+      subtitle2: loc(HEADER.es.subtitle2, HEADER.en.subtitle2),
+      cta1: loc(HEADER.es.cta1, HEADER.en.cta1),
+      cta1Link: loc(HEADER.es.cta1Link, HEADER.en.cta1Link),
+      cta2: loc(HEADER.es.cta2, HEADER.en.cta2),
+      cta2Link: loc(HEADER.es.cta2Link, HEADER.en.cta2Link),
+      backgroundImage: { [defaultLocale]: linkToAsset(headerBgAsset) },
+    }),
+  );
+
+  await runStep("entry:dbtAbout", async () =>
+    upsertEntryByKey(envApi, "dbtAbout", "luminous.about", {
+      key: makeKeyField("luminous.about"),
+      title: loc(ABOUT.es.title, ABOUT.en.title),
+      body: loc(ABOUT.es.body, ABOUT.en.body),
+      linkText: loc(ABOUT.es.linkText, ABOUT.en.linkText),
+      linkUrl: loc(ABOUT.es.linkUrl, ABOUT.en.linkUrl),
+      image: { [defaultLocale]: linkToAsset(aboutAsset) },
+    }),
+  );
+
+  await runStep("entry:dbtSpaces", async () =>
+    upsertEntryByKey(envApi, "dbtSpaces", "luminous.spaces", {
+      key: makeKeyField("luminous.spaces"),
+      eyebrow: loc(SPACES.es.eyebrow, SPACES.en.eyebrow),
+      title: loc(SPACES.es.title, SPACES.en.title),
+      items: { [defaultLocale]: spacesItemEntries.map(linkToEntry) },
+    }),
+  );
+
+  await runStep("entry:dbtTherapies", async () =>
+    upsertEntryByKey(envApi, "dbtTherapies", "luminous.therapies", {
+      key: makeKeyField("luminous.therapies"),
+      title: loc(THERAPIES.es.title, THERAPIES.en.title),
+      items: { [defaultLocale]: therapiesItemEntries.map(linkToEntry) },
+    }),
+  );
+
+  await runStep("entry:dbtServices", async () =>
+    upsertEntryByKey(envApi, "dbtServices", "luminous.services", {
+      key: makeKeyField("luminous.services"),
+      title: loc(SERVICES.es.title, SERVICES.en.title),
+      subtitle: loc(SERVICES.es.subtitle, SERVICES.en.subtitle),
+      items: { [defaultLocale]: servicesItemEntries.map(linkToEntry) },
+    }),
+  );
+
+  await runStep("entry:dbtProcess", async () =>
+    upsertEntryByKey(envApi, "dbtProcess", "luminous.process", {
+      key: makeKeyField("luminous.process"),
+      title: loc(PROCESS.es.title, PROCESS.en.title),
+      intro: loc(PROCESS.es.intro, PROCESS.en.intro),
+      steps: { [defaultLocale]: processStepEntries.map(linkToEntry) },
+    }),
+  );
+
+  await runStep("entry:dbtTeam", async () =>
+    upsertEntryByKey(envApi, "dbtTeam", "luminous.team", {
+      key: makeKeyField("luminous.team"),
+      title: loc(TEAM.es.title, TEAM.en.title),
+      members: { [defaultLocale]: teamMemberEntries.map(linkToEntry) },
+    }),
+  );
+
+  await runStep("entry:dbtContact", async () =>
+    upsertEntryByKey(envApi, "dbtContact", "luminous.contact", {
+      key: makeKeyField("luminous.contact"),
+      title: loc(CONTACT.es.title, CONTACT.en.title),
+      address: loc(CONTACT.es.address, CONTACT.en.address),
+      whatsapp: loc(CONTACT.es.whatsapp, CONTACT.en.whatsapp),
+      instagram: loc(CONTACT.es.instagram, CONTACT.en.instagram),
+      email: loc(CONTACT.es.email, CONTACT.en.email),
+      hoursWeekdays: loc(CONTACT.es.hours.weekdays, CONTACT.en.hours.weekdays),
+      hoursSaturday: loc(CONTACT.es.hours.saturday, CONTACT.en.hours.saturday),
+      hoursSunday: loc(CONTACT.es.hours.sunday, CONTACT.en.hours.sunday),
+    }),
+  );
+
+  await runStep("entry:dbtFooter", async () =>
+    upsertEntryByKey(envApi, "dbtFooter", "luminous.footer", {
+      key: makeKeyField("luminous.footer"),
+      quote: loc(FOOTER.es.quote, FOOTER.en.quote),
+      text: loc(FOOTER.es.text, FOOTER.en.text),
+    }),
+  );
+
+  // Styles entries
+  await runStep("entry:dbtStylesGenerales", async () =>
+    upsertEntryByKey(envApi, "dbtStylesGenerales", "luminous.styles.generales", {
+      key: makeKeyField("luminous.styles.generales"),
+      primary: { [defaultLocale]: STYLES["luminous.styles.generales"].colors.primary },
+      secondary: { [defaultLocale]: STYLES["luminous.styles.generales"].colors.secondary },
+      fontFamily: { [defaultLocale]: STYLES["luminous.styles.generales"].typography.fontFamily },
+      baseSize: { [defaultLocale]: STYLES["luminous.styles.generales"].typography.baseSize },
+      logoUrl: { [defaultLocale]: STYLES["luminous.styles.generales"].assets.logoUrl },
+    }),
+  );
+
+  const styleTypeByKey: Record<string, string> = {
+    "luminous.styles.header": "dbtStylesHeader",
+    "luminous.styles.about": "dbtStylesAbout",
+    "luminous.styles.spaces": "dbtStylesSpaces",
+    "luminous.styles.therapies": "dbtStylesTherapies",
+    "luminous.styles.services": "dbtStylesServices",
+    "luminous.styles.process": "dbtStylesProcess",
+    "luminous.styles.team": "dbtStylesTeam",
+    "luminous.styles.contact": "dbtStylesContact",
+    "luminous.styles.footer": "dbtStylesFooter",
+  };
+
+  for (const k of Object.keys(styleTypeByKey)) {
+    const ct = styleTypeByKey[k];
+    await runStep(`entry:${ct}`, async () =>
+      upsertEntryByKey(envApi, ct, k, {
+        key: makeKeyField(k),
+        ...Object.fromEntries(
+          Object.entries(STYLES[k]).map(([field, value]) => [field, { [defaultLocale]: value }]),
+        ),
+      }),
+    );
+  }
+
   for (const key of Object.keys(CONTENT)) {
     for (const locale of localesToSeed) {
       await runStep(`upsertContent:${key}:${locale}`, async () =>

--- a/server/contentful-seed.ts
+++ b/server/contentful-seed.ts
@@ -1759,21 +1759,44 @@ export async function seedContentfulFromDefaults() {
       "luminous.styles.footer": "dbtStylesFooter",
     };
 
+    const unifiedSectionTypeByStyleKey: Record<string, string> = {
+      "luminous.styles.header": "dbtHeader",
+      "luminous.styles.about": "dbtAbout",
+      "luminous.styles.spaces": "dbtSpaces",
+      "luminous.styles.therapies": "dbtTherapies",
+      "luminous.styles.services": "dbtServices",
+      "luminous.styles.process": "dbtProcess",
+      "luminous.styles.team": "dbtTeam",
+      "luminous.styles.contact": "dbtContact",
+      "luminous.styles.footer": "dbtFooter",
+    };
+
     for (const k of Object.keys(styleTypeByKey)) {
+      const unifiedSectionType = unifiedSectionTypeByStyleKey[k];
+      if (
+        unifiedSectionType &&
+        unifiedStylesEnabledByContentType[unifiedSectionType]
+      ) {
+        // Unified styles are stored in the section entry; keep legacy style entry as fallback only.
+        continue;
+      }
+
       const ct = styleTypeByKey[k];
       await runStep(`entry:${ct}`, async () =>
         upsertEntryByKey(envApi, ct, k, {
           key: makeKeyField(k),
           ...Object.fromEntries(
-            Object.entries(STYLES[k]).map(([field, value]) => [field, { [defaultLocale]: value }]),
+            Object.entries(STYLES[k]).map(([field, value]) => [field, nonLocalized(value)]),
           ),
         }),
       );
     }
   } else {
-    warnings.push(
-      "Se omitió la creación de estilos estructurados en Contentful (faltan permisos de modelo). La web seguirá usando los estilos legacy.",
-    );
+    if (!unifiedStylesEnabled) {
+      warnings.push(
+        "Se omitió la creación de estilos estructurados en Contentful (faltan permisos de modelo). La web seguirá usando los estilos legacy.",
+      );
+    }
   }
 
   for (const key of Object.keys(CONTENT)) {
@@ -1812,7 +1835,7 @@ export async function seedContentfulFromDefaults() {
     },
     warnings: warnings.length ? warnings : undefined,
     structured: {
-      stylesEnabled: structuredStylesEnabled,
+      stylesEnabled: structuredStylesEnabled || unifiedStylesEnabled,
     },
   };
 }

--- a/server/contentful-seed.ts
+++ b/server/contentful-seed.ts
@@ -1662,5 +1662,9 @@ export async function seedContentfulFromDefaults() {
       styleKeys: Object.keys(STYLES),
       settings: true,
     },
+    warnings: warnings.length ? warnings : undefined,
+    structured: {
+      stylesEnabled: structuredStylesEnabled,
+    },
   };
 }

--- a/server/contentful-seed.ts
+++ b/server/contentful-seed.ts
@@ -1580,6 +1580,16 @@ export async function seedContentfulFromDefaults() {
       cta2: loc(HEADER.es.cta2, HEADER.en.cta2),
       cta2Link: loc(HEADER.es.cta2Link, HEADER.en.cta2Link),
       backgroundImage: { [defaultLocale]: linkToAsset(headerBgAsset) },
+      ...(unifiedStylesEnabledByContentType.dbtHeader
+        ? {
+            title1Color: nonLocalized(STYLES["luminous.styles.header"].title1Color),
+            title2Color: nonLocalized(STYLES["luminous.styles.header"].title2Color),
+            title1Size: nonLocalized(STYLES["luminous.styles.header"].title1Size),
+            title2Size: nonLocalized(STYLES["luminous.styles.header"].title2Size),
+            subtitle1Color: nonLocalized(STYLES["luminous.styles.header"].subtitle1Color),
+            subtitle2Color: nonLocalized(STYLES["luminous.styles.header"].subtitle2Color),
+          }
+        : {}),
     }),
   );
 
@@ -1591,6 +1601,15 @@ export async function seedContentfulFromDefaults() {
       linkText: loc(ABOUT.es.linkText, ABOUT.en.linkText),
       linkUrl: loc(ABOUT.es.linkUrl, ABOUT.en.linkUrl),
       image: { [defaultLocale]: linkToAsset(aboutAsset) },
+      ...(unifiedStylesEnabledByContentType.dbtAbout
+        ? {
+            titleColor: nonLocalized(STYLES["luminous.styles.about"].titleColor),
+            bodyColor: nonLocalized(STYLES["luminous.styles.about"].bodyColor),
+            backgroundColor: nonLocalized(STYLES["luminous.styles.about"].backgroundColor),
+            titleSize: nonLocalized(STYLES["luminous.styles.about"].titleSize),
+            bodySize: nonLocalized(STYLES["luminous.styles.about"].bodySize),
+          }
+        : {}),
     }),
   );
 
@@ -1600,6 +1619,12 @@ export async function seedContentfulFromDefaults() {
       eyebrow: loc(SPACES.es.eyebrow, SPACES.en.eyebrow),
       title: loc(SPACES.es.title, SPACES.en.title),
       items: { [defaultLocale]: spacesItemEntries.map(linkToEntry) },
+      ...(unifiedStylesEnabledByContentType.dbtSpaces
+        ? {
+            textColor: nonLocalized(STYLES["luminous.styles.spaces"].textColor),
+            speedSeconds: nonLocalized(STYLES["luminous.styles.spaces"].speedSeconds),
+          }
+        : {}),
     }),
   );
 
@@ -1608,6 +1633,13 @@ export async function seedContentfulFromDefaults() {
       key: makeKeyField("luminous.therapies"),
       title: loc(THERAPIES.es.title, THERAPIES.en.title),
       items: { [defaultLocale]: therapiesItemEntries.map(linkToEntry) },
+      ...(unifiedStylesEnabledByContentType.dbtTherapies
+        ? {
+            titleColor: nonLocalized(STYLES["luminous.styles.therapies"].titleColor),
+            itemTitleColor: nonLocalized(STYLES["luminous.styles.therapies"].itemTitleColor),
+            itemDescColor: nonLocalized(STYLES["luminous.styles.therapies"].itemDescColor),
+          }
+        : {}),
     }),
   );
 
@@ -1617,6 +1649,13 @@ export async function seedContentfulFromDefaults() {
       title: loc(SERVICES.es.title, SERVICES.en.title),
       subtitle: loc(SERVICES.es.subtitle, SERVICES.en.subtitle),
       items: { [defaultLocale]: servicesItemEntries.map(linkToEntry) },
+      ...(unifiedStylesEnabledByContentType.dbtServices
+        ? {
+            titleColor: nonLocalized(STYLES["luminous.styles.services"].titleColor),
+            subtitleColor: nonLocalized(STYLES["luminous.styles.services"].subtitleColor),
+            itemTitleColor: nonLocalized(STYLES["luminous.styles.services"].itemTitleColor),
+          }
+        : {}),
     }),
   );
 
@@ -1626,6 +1665,14 @@ export async function seedContentfulFromDefaults() {
       title: loc(PROCESS.es.title, PROCESS.en.title),
       intro: loc(PROCESS.es.intro, PROCESS.en.intro),
       steps: { [defaultLocale]: processStepEntries.map(linkToEntry) },
+      ...(unifiedStylesEnabledByContentType.dbtProcess
+        ? {
+            titleColor: nonLocalized(STYLES["luminous.styles.process"].titleColor),
+            introColor: nonLocalized(STYLES["luminous.styles.process"].introColor),
+            stepTitleColor: nonLocalized(STYLES["luminous.styles.process"].stepTitleColor),
+            stepDescColor: nonLocalized(STYLES["luminous.styles.process"].stepDescColor),
+          }
+        : {}),
     }),
   );
 
@@ -1634,6 +1681,13 @@ export async function seedContentfulFromDefaults() {
       key: makeKeyField("luminous.team"),
       title: loc(TEAM.es.title, TEAM.en.title),
       members: { [defaultLocale]: teamMemberEntries.map(linkToEntry) },
+      ...(unifiedStylesEnabledByContentType.dbtTeam
+        ? {
+            titleColor: nonLocalized(STYLES["luminous.styles.team"].titleColor),
+            nameColor: nonLocalized(STYLES["luminous.styles.team"].nameColor),
+            roleColor: nonLocalized(STYLES["luminous.styles.team"].roleColor),
+          }
+        : {}),
     }),
   );
 
@@ -1648,6 +1702,12 @@ export async function seedContentfulFromDefaults() {
       hoursWeekdays: loc(CONTACT.es.hours.weekdays, CONTACT.en.hours.weekdays),
       hoursSaturday: loc(CONTACT.es.hours.saturday, CONTACT.en.hours.saturday),
       hoursSunday: loc(CONTACT.es.hours.sunday, CONTACT.en.hours.sunday),
+      ...(unifiedStylesEnabledByContentType.dbtContact
+        ? {
+            titleColor: nonLocalized(STYLES["luminous.styles.contact"].titleColor),
+            infoColor: nonLocalized(STYLES["luminous.styles.contact"].infoColor),
+          }
+        : {}),
     }),
   );
 
@@ -1656,6 +1716,11 @@ export async function seedContentfulFromDefaults() {
       key: makeKeyField("luminous.footer"),
       quote: loc(FOOTER.es.quote, FOOTER.en.quote),
       text: loc(FOOTER.es.text, FOOTER.en.text),
+      ...(unifiedStylesEnabledByContentType.dbtFooter
+        ? {
+            textColor: nonLocalized(STYLES["luminous.styles.footer"].textColor),
+          }
+        : {}),
     }),
   );
 

--- a/server/contentful-seed.ts
+++ b/server/contentful-seed.ts
@@ -1576,39 +1576,55 @@ export async function seedContentfulFromDefaults() {
     }),
   );
 
-  // Styles entries
-  await runStep("entry:dbtStylesGenerales", async () =>
-    upsertEntryByKey(envApi, "dbtStylesGenerales", "luminous.styles.generales", {
-      key: makeKeyField("luminous.styles.generales"),
-      primary: { [defaultLocale]: STYLES["luminous.styles.generales"].colors.primary },
-      secondary: { [defaultLocale]: STYLES["luminous.styles.generales"].colors.secondary },
-      fontFamily: { [defaultLocale]: STYLES["luminous.styles.generales"].typography.fontFamily },
-      baseSize: { [defaultLocale]: STYLES["luminous.styles.generales"].typography.baseSize },
-      logoUrl: { [defaultLocale]: STYLES["luminous.styles.generales"].assets.logoUrl },
-    }),
-  );
-
-  const styleTypeByKey: Record<string, string> = {
-    "luminous.styles.header": "dbtStylesHeader",
-    "luminous.styles.about": "dbtStylesAbout",
-    "luminous.styles.spaces": "dbtStylesSpaces",
-    "luminous.styles.therapies": "dbtStylesTherapies",
-    "luminous.styles.services": "dbtStylesServices",
-    "luminous.styles.process": "dbtStylesProcess",
-    "luminous.styles.team": "dbtStylesTeam",
-    "luminous.styles.contact": "dbtStylesContact",
-    "luminous.styles.footer": "dbtStylesFooter",
-  };
-
-  for (const k of Object.keys(styleTypeByKey)) {
-    const ct = styleTypeByKey[k];
-    await runStep(`entry:${ct}`, async () =>
-      upsertEntryByKey(envApi, ct, k, {
-        key: makeKeyField(k),
-        ...Object.fromEntries(
-          Object.entries(STYLES[k]).map(([field, value]) => [field, { [defaultLocale]: value }]),
-        ),
+  if (structuredStylesEnabled) {
+    // Styles entries
+    await runStep("entry:dbtStylesGenerales", async () =>
+      upsertEntryByKey(envApi, "dbtStylesGenerales", "luminous.styles.generales", {
+        key: makeKeyField("luminous.styles.generales"),
+        primary: {
+          [defaultLocale]: STYLES["luminous.styles.generales"].colors.primary,
+        },
+        secondary: {
+          [defaultLocale]: STYLES["luminous.styles.generales"].colors.secondary,
+        },
+        fontFamily: {
+          [defaultLocale]: STYLES["luminous.styles.generales"].typography.fontFamily,
+        },
+        baseSize: {
+          [defaultLocale]: STYLES["luminous.styles.generales"].typography.baseSize,
+        },
+        logoUrl: {
+          [defaultLocale]: STYLES["luminous.styles.generales"].assets.logoUrl,
+        },
       }),
+    );
+
+    const styleTypeByKey: Record<string, string> = {
+      "luminous.styles.header": "dbtStylesHeader",
+      "luminous.styles.about": "dbtStylesAbout",
+      "luminous.styles.spaces": "dbtStylesSpaces",
+      "luminous.styles.therapies": "dbtStylesTherapies",
+      "luminous.styles.services": "dbtStylesServices",
+      "luminous.styles.process": "dbtStylesProcess",
+      "luminous.styles.team": "dbtStylesTeam",
+      "luminous.styles.contact": "dbtStylesContact",
+      "luminous.styles.footer": "dbtStylesFooter",
+    };
+
+    for (const k of Object.keys(styleTypeByKey)) {
+      const ct = styleTypeByKey[k];
+      await runStep(`entry:${ct}`, async () =>
+        upsertEntryByKey(envApi, ct, k, {
+          key: makeKeyField(k),
+          ...Object.fromEntries(
+            Object.entries(STYLES[k]).map(([field, value]) => [field, { [defaultLocale]: value }]),
+          ),
+        }),
+      );
+    }
+  } else {
+    warnings.push(
+      "Se omitió la creación de estilos estructurados en Contentful (faltan permisos de modelo). La web seguirá usando los estilos legacy.",
     );
   }
 

--- a/server/contentful-seed.ts
+++ b/server/contentful-seed.ts
@@ -278,6 +278,35 @@ export async function seedContentfulFromDefaults() {
     space.getEnvironment(environmentId),
   );
 
+  const warnings: string[] = [];
+
+  async function runOptionalStep(label: string, fn: () => Promise<void>) {
+    try {
+      await fn();
+      return true;
+    } catch (e: any) {
+      const info = parseContentfulError(e);
+      if ((info.status || 0) === 403) {
+        const extra = [
+          info.status ? `status=${info.status}` : null,
+          info.code ? `code=${info.code}` : null,
+          info.requestId ? `requestId=${info.requestId}` : null,
+        ]
+          .filter(Boolean)
+          .join(", ");
+
+        warnings.push(
+          extra
+            ? `Permiso insuficiente en Contentful para "${label}" (${extra}). Se omitió este paso.`
+            : `Permiso insuficiente en Contentful para "${label}". Se omitió este paso.`,
+        );
+        return false;
+      }
+
+      throw e;
+    }
+  }
+
   let localesRes = await runStep("getLocales", async () => envApi.getLocales());
   let locales: LocaleInfo[] = (localesRes?.items || []).map((l: any) => ({
     code: String(l.code),

--- a/server/contentful-store.ts
+++ b/server/contentful-store.ts
@@ -986,13 +986,13 @@ const structuredHandlers: Record<string, StructuredKeyHandler> = {
           entry.fields?.title1Size,
           localeCode,
           fallbackLocaleCode,
-        ) ?? 48,
+        ) ?? undefined,
       title2Size:
         pickLocaleValue<number>(
           entry.fields?.title2Size,
           localeCode,
           fallbackLocaleCode,
-        ) ?? 40,
+        ) ?? undefined,
       subtitle1Color:
         pickLocaleValue<string>(
           entry.fields?.subtitle1Color,
@@ -1045,13 +1045,13 @@ const structuredHandlers: Record<string, StructuredKeyHandler> = {
           entry.fields?.titleSize,
           localeCode,
           fallbackLocaleCode,
-        ) ?? 50,
+        ) ?? undefined,
       bodySize:
         pickLocaleValue<number>(
           entry.fields?.bodySize,
           localeCode,
           fallbackLocaleCode,
-        ) ?? 18,
+        ) ?? undefined,
       backgroundImage,
     };
   },
@@ -1069,7 +1069,7 @@ const structuredHandlers: Record<string, StructuredKeyHandler> = {
           entry.fields?.speedSeconds,
           localeCode,
           fallbackLocaleCode,
-        ) ?? 25.6,
+        ) ?? undefined,
     };
   },
 

--- a/server/contentful-store.ts
+++ b/server/contentful-store.ts
@@ -1177,6 +1177,76 @@ const structuredHandlers: Record<string, StructuredKeyHandler> = {
   },
 };
 
+const STRUCTURED_EMPTY = Symbol("structured-empty");
+
+function isStructuredResultEmpty(key: string, data: any) {
+  if (!data || typeof data !== "object") return true;
+
+  const hasAnyText = (...values: any[]) =>
+    values.some((v) => typeof v === "string" && v.trim().length > 0);
+
+  if (key === "luminous.header") {
+    return !hasAnyText(
+      data.title1,
+      data.title2,
+      data.subtitle1,
+      data.subtitle2,
+      data.cta1,
+      data.cta2,
+      data.backgroundImage,
+    );
+  }
+
+  if (key === "luminous.about") {
+    return !hasAnyText(data.title, data.body, data.image);
+  }
+
+  if (key === "luminous.spaces") {
+    return !hasAnyText(data.eyebrow, data.title) && !(data.items?.length > 0);
+  }
+
+  if (key === "luminous.therapies" || key === "luminous.services") {
+    return !hasAnyText(data.title, data.subtitle) && !(data.items?.length > 0);
+  }
+
+  if (key === "luminous.process") {
+    return !hasAnyText(data.title, data.intro) && !(data.steps?.length > 0);
+  }
+
+  if (key === "luminous.team") {
+    return !hasAnyText(data.title) && !(data.members?.length > 0);
+  }
+
+  if (key === "luminous.contact") {
+    return !hasAnyText(
+      data.title,
+      data.address,
+      data.whatsapp,
+      data.instagram,
+      data.email,
+      data?.hours?.weekdays,
+      data?.hours?.saturday,
+      data?.hours?.sunday,
+    );
+  }
+
+  if (key === "luminous.footer") {
+    return !hasAnyText(data.quote, data.text);
+  }
+
+  if (key === "luminous.seo") {
+    return !hasAnyText(data.title, data.description, data.canonical, data.ogUrl);
+  }
+
+  // styles
+  if (key.startsWith("luminous.styles.")) {
+    // If nothing is set, keep using legacy JSON so existing styling doesn't change.
+    return !JSON.stringify(data).replace(/\s+/g, "").includes("#");
+  }
+
+  return false;
+}
+
 async function tryGetStructuredContent(
   cfg: ContentfulStoreConfig,
   locale: Locale,
@@ -1194,7 +1264,7 @@ async function tryGetStructuredContent(
     resolved.defaultLocale,
   );
 
-  if (!item) return null;
+  if (!item) return STRUCTURED_EMPTY;
 
   const localeCode = resolved.localeMap[locale] || resolved.defaultLocale;
   const data = await handler({
@@ -1204,6 +1274,8 @@ async function tryGetStructuredContent(
     localeCode,
     fallbackLocaleCode: resolved.defaultLocale,
   });
+
+  if (isStructuredResultEmpty(key, data)) return STRUCTURED_EMPTY;
 
   return data;
 }
@@ -1219,7 +1291,7 @@ export async function contentfulGetContent<T = any>(
 
   try {
     const structured = await tryGetStructuredContent(cfg, locale, resolved, key);
-    if (structured !== undefined) {
+    if (structured !== undefined && structured !== STRUCTURED_EMPTY) {
       return { configured: true as const, data: (structured as any) as T | null };
     }
 

--- a/server/contentful-store.ts
+++ b/server/contentful-store.ts
@@ -243,6 +243,971 @@ async function findContentEntryByKey(
   }
 }
 
+type ContentfulIncludes = {
+  Entry?: any[];
+  Asset?: any[];
+};
+
+type DeliveryQueryResult = {
+  item: any | null;
+  includes: ContentfulIncludes | null;
+};
+
+function normalizeContentfulAssetUrl(url: string) {
+  const trimmed = String(url || "").trim();
+  if (!trimmed) return "";
+  if (trimmed.startsWith("//")) return `https:${trimmed}`;
+  if (trimmed.startsWith("http://") || trimmed.startsWith("https://"))
+    return trimmed;
+  return `https://${trimmed.replace(/^\/+/, "")}`;
+}
+
+function buildIncludesIndex(includes: ContentfulIncludes | null) {
+  const entriesById = new Map<string, any>();
+  const assetsById = new Map<string, any>();
+
+  for (const e of includes?.Entry || []) {
+    const id = e?.sys?.id;
+    if (id) entriesById.set(String(id), e);
+  }
+
+  for (const a of includes?.Asset || []) {
+    const id = a?.sys?.id;
+    if (id) assetsById.set(String(id), a);
+  }
+
+  return { entriesById, assetsById };
+}
+
+function isLinkToAsset(v: any) {
+  return v?.sys?.type === "Link" && v?.sys?.linkType === "Asset" && v?.sys?.id;
+}
+
+function isLinkToEntry(v: any) {
+  return v?.sys?.type === "Link" && v?.sys?.linkType === "Entry" && v?.sys?.id;
+}
+
+function isAsset(v: any) {
+  return v?.sys?.type === "Asset" && v?.sys?.id;
+}
+
+function isEntry(v: any) {
+  return v?.sys?.type === "Entry" && v?.sys?.id;
+}
+
+async function findDeliveryEntryByKey(
+  cfg: ContentfulStoreConfig,
+  contentType: string,
+  key: string,
+  defaultLocale: string,
+): Promise<DeliveryQueryResult> {
+  const client: any = getDeliveryClient(cfg, false);
+  const allLocalesClient: any = client?.withAllLocales
+    ? client.withAllLocales
+    : client;
+
+  const q: Record<string, any> = {
+    content_type: contentType,
+    limit: 1,
+    include: 10,
+  };
+  q[`fields.${cfg.fieldKey}`] = key;
+
+  try {
+    const resAllLocales = await allLocalesClient.getEntries(q);
+    if (resAllLocales.items?.length)
+      return {
+        item: resAllLocales.items[0] as any,
+        includes: (resAllLocales.includes || null) as any,
+      };
+
+    const resDefault = await client.getEntries({
+      ...q,
+      locale: defaultLocale,
+    });
+    if (resDefault.items?.length)
+      return {
+        item: resDefault.items[0] as any,
+        includes: (resDefault.includes || null) as any,
+      };
+
+    return { item: null, includes: null };
+  } catch (e: any) {
+    if (isUnknownContentTypeError(e)) return { item: null, includes: null };
+    throw e;
+  }
+}
+
+async function resolveAssetUrl(
+  cfg: ContentfulStoreConfig,
+  value: any,
+  localeCode: string,
+  fallbackLocaleCode: string,
+  includes: ContentfulIncludes | null,
+) {
+  const deliveryClient: any = getDeliveryClient(cfg, false);
+  const { assetsById } = buildIncludesIndex(includes);
+
+  const urlFromAsset = (asset: any): string => {
+    const file = pickLocaleValue<any>(
+      asset?.fields?.file,
+      localeCode,
+      fallbackLocaleCode,
+    );
+    const rawUrl = file?.url || "";
+    return normalizeContentfulAssetUrl(String(rawUrl));
+  };
+
+  if (!value) return "";
+
+  if (typeof value === "string") return value;
+
+  if (isLinkToAsset(value)) {
+    const id = String(value.sys.id);
+    const fromIncludes = assetsById.get(id);
+    if (fromIncludes) return urlFromAsset(fromIncludes);
+
+    try {
+      const asset: any = await deliveryClient.getAsset(id, { locale: "*" });
+      return urlFromAsset(asset);
+    } catch {
+      return "";
+    }
+  }
+
+  if (isAsset(value)) return urlFromAsset(value);
+
+  return "";
+}
+
+async function resolveEntry(
+  cfg: ContentfulStoreConfig,
+  value: any,
+  includes: ContentfulIncludes | null,
+) {
+  const deliveryClient: any = getDeliveryClient(cfg, false);
+  const { entriesById } = buildIncludesIndex(includes);
+
+  if (!value) return null;
+  if (isEntry(value)) return value;
+
+  if (isLinkToEntry(value)) {
+    const id = String(value.sys.id);
+    const fromIncludes = entriesById.get(id);
+    if (fromIncludes) return fromIncludes;
+
+    try {
+      const entry: any = await deliveryClient.getEntry(id, { locale: "*" });
+      return entry;
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+const STRUCTURED_CONTENT_TYPES = {
+  seo: "dbtSeo",
+  header: "dbtHeader",
+  about: "dbtAbout",
+  spaces: "dbtSpaces",
+  therapies: "dbtTherapies",
+  services: "dbtServices",
+  process: "dbtProcess",
+  team: "dbtTeam",
+  contact: "dbtContact",
+  footer: "dbtFooter",
+
+  // styles
+  stylesGenerales: "dbtStylesGenerales",
+  stylesHeader: "dbtStylesHeader",
+  stylesAbout: "dbtStylesAbout",
+  stylesSpaces: "dbtStylesSpaces",
+  stylesTherapies: "dbtStylesTherapies",
+  stylesServices: "dbtStylesServices",
+  stylesProcess: "dbtStylesProcess",
+  stylesTeam: "dbtStylesTeam",
+  stylesContact: "dbtStylesContact",
+  stylesFooter: "dbtStylesFooter",
+
+  // item types
+  spacesItem: "dbtSpacesItem",
+  therapiesItem: "dbtTherapiesItem",
+  servicesItem: "dbtServicesItem",
+  processStep: "dbtProcessStep",
+  teamMember: "dbtTeamMember",
+} as const;
+
+type StructuredKeyHandler = (args: {
+  cfg: ContentfulStoreConfig;
+  entry: any;
+  includes: ContentfulIncludes | null;
+  localeCode: string;
+  fallbackLocaleCode: string;
+}) => Promise<any>;
+
+const STRUCTURED_KEY_TO_CONTENT_TYPE: Record<string, string> = {
+  "luminous.seo": STRUCTURED_CONTENT_TYPES.seo,
+  "luminous.header": STRUCTURED_CONTENT_TYPES.header,
+  "luminous.about": STRUCTURED_CONTENT_TYPES.about,
+  "luminous.spaces": STRUCTURED_CONTENT_TYPES.spaces,
+  "luminous.therapies": STRUCTURED_CONTENT_TYPES.therapies,
+  "luminous.services": STRUCTURED_CONTENT_TYPES.services,
+  "luminous.process": STRUCTURED_CONTENT_TYPES.process,
+  "luminous.team": STRUCTURED_CONTENT_TYPES.team,
+  "luminous.contact": STRUCTURED_CONTENT_TYPES.contact,
+  "luminous.footer": STRUCTURED_CONTENT_TYPES.footer,
+
+  "luminous.styles.generales": STRUCTURED_CONTENT_TYPES.stylesGenerales,
+  "luminous.styles.header": STRUCTURED_CONTENT_TYPES.stylesHeader,
+  "luminous.styles.about": STRUCTURED_CONTENT_TYPES.stylesAbout,
+  "luminous.styles.spaces": STRUCTURED_CONTENT_TYPES.stylesSpaces,
+  "luminous.styles.therapies": STRUCTURED_CONTENT_TYPES.stylesTherapies,
+  "luminous.styles.services": STRUCTURED_CONTENT_TYPES.stylesServices,
+  "luminous.styles.process": STRUCTURED_CONTENT_TYPES.stylesProcess,
+  "luminous.styles.team": STRUCTURED_CONTENT_TYPES.stylesTeam,
+  "luminous.styles.contact": STRUCTURED_CONTENT_TYPES.stylesContact,
+  "luminous.styles.footer": STRUCTURED_CONTENT_TYPES.stylesFooter,
+};
+
+const structuredHandlers: Record<string, StructuredKeyHandler> = {
+  "luminous.seo": async ({ entry, localeCode, fallbackLocaleCode }) => {
+    const title = pickLocaleValue<string>(
+      entry.fields?.title,
+      localeCode,
+      fallbackLocaleCode,
+    );
+    const description = pickLocaleValue<string>(
+      entry.fields?.description,
+      localeCode,
+      fallbackLocaleCode,
+    );
+    const canonical = pickLocaleValue<string>(
+      entry.fields?.canonical,
+      localeCode,
+      fallbackLocaleCode,
+    );
+    const ogUrl = pickLocaleValue<string>(
+      entry.fields?.ogUrl,
+      localeCode,
+      fallbackLocaleCode,
+    );
+    const ogImage = pickLocaleValue<string>(
+      entry.fields?.ogImage,
+      localeCode,
+      fallbackLocaleCode,
+    );
+    const keywords = pickLocaleValue<string>(
+      entry.fields?.keywords,
+      localeCode,
+      fallbackLocaleCode,
+    );
+
+    return {
+      title: title ?? "",
+      description: description ?? "",
+      canonical: canonical ?? "",
+      ogUrl: ogUrl ?? "",
+      ogImage: ogImage ?? "",
+      keywords: keywords ?? "",
+    };
+  },
+
+  "luminous.header": async ({ cfg, entry, includes, localeCode, fallbackLocaleCode }) => {
+    const backgroundImage = await resolveAssetUrl(
+      cfg,
+      pickLocaleValue<any>(
+        entry.fields?.backgroundImage,
+        localeCode,
+        fallbackLocaleCode,
+      ),
+      localeCode,
+      fallbackLocaleCode,
+      includes,
+    );
+
+    return {
+      title1:
+        pickLocaleValue<string>(entry.fields?.title1, localeCode, fallbackLocaleCode) ??
+        "",
+      title2:
+        pickLocaleValue<string>(entry.fields?.title2, localeCode, fallbackLocaleCode) ??
+        "",
+      subtitle1:
+        pickLocaleValue<string>(
+          entry.fields?.subtitle1,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+      subtitle2:
+        pickLocaleValue<string>(
+          entry.fields?.subtitle2,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+      cta1:
+        pickLocaleValue<string>(entry.fields?.cta1, localeCode, fallbackLocaleCode) ??
+        "",
+      cta1Link:
+        pickLocaleValue<string>(
+          entry.fields?.cta1Link,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+      cta2:
+        pickLocaleValue<string>(entry.fields?.cta2, localeCode, fallbackLocaleCode) ??
+        "",
+      cta2Link:
+        pickLocaleValue<string>(
+          entry.fields?.cta2Link,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+      backgroundImage,
+    };
+  },
+
+  "luminous.about": async ({ cfg, entry, includes, localeCode, fallbackLocaleCode }) => {
+    const image = await resolveAssetUrl(
+      cfg,
+      pickLocaleValue<any>(entry.fields?.image, localeCode, fallbackLocaleCode),
+      localeCode,
+      fallbackLocaleCode,
+      includes,
+    );
+
+    return {
+      title:
+        pickLocaleValue<string>(entry.fields?.title, localeCode, fallbackLocaleCode) ??
+        "",
+      body:
+        pickLocaleValue<string>(entry.fields?.body, localeCode, fallbackLocaleCode) ??
+        "",
+      linkText:
+        pickLocaleValue<string>(
+          entry.fields?.linkText,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+      linkUrl:
+        pickLocaleValue<string>(entry.fields?.linkUrl, localeCode, fallbackLocaleCode) ??
+        "",
+      image,
+    };
+  },
+
+  "luminous.spaces": async ({ cfg, entry, includes, localeCode, fallbackLocaleCode }) => {
+    const items =
+      pickLocaleValue<any[]>(entry.fields?.items, localeCode, fallbackLocaleCode) ||
+      [];
+
+    const resolvedItems: any[] = [];
+    for (const it of items) {
+      const child = await resolveEntry(cfg, it, includes);
+      if (!child) continue;
+
+      const image = await resolveAssetUrl(
+        cfg,
+        pickLocaleValue<any>(
+          child.fields?.image,
+          localeCode,
+          fallbackLocaleCode,
+        ),
+        localeCode,
+        fallbackLocaleCode,
+        includes,
+      );
+
+      resolvedItems.push({
+        title:
+          pickLocaleValue<string>(
+            child.fields?.title,
+            localeCode,
+            fallbackLocaleCode,
+          ) ?? "",
+        href:
+          pickLocaleValue<string>(
+            child.fields?.href,
+            localeCode,
+            fallbackLocaleCode,
+          ) ?? "",
+        image,
+      });
+    }
+
+    return {
+      eyebrow:
+        pickLocaleValue<string>(
+          entry.fields?.eyebrow,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+      title:
+        pickLocaleValue<string>(entry.fields?.title, localeCode, fallbackLocaleCode) ??
+        "",
+      items: resolvedItems,
+    };
+  },
+
+  "luminous.therapies": async ({ cfg, entry, includes, localeCode, fallbackLocaleCode }) => {
+    const items =
+      pickLocaleValue<any[]>(entry.fields?.items, localeCode, fallbackLocaleCode) ||
+      [];
+
+    const resolvedItems: any[] = [];
+    for (const it of items) {
+      const child = await resolveEntry(cfg, it, includes);
+      if (!child) continue;
+
+      const image = await resolveAssetUrl(
+        cfg,
+        pickLocaleValue<any>(
+          child.fields?.image,
+          localeCode,
+          fallbackLocaleCode,
+        ),
+        localeCode,
+        fallbackLocaleCode,
+        includes,
+      );
+
+      resolvedItems.push({
+        title:
+          pickLocaleValue<string>(
+            child.fields?.title,
+            localeCode,
+            fallbackLocaleCode,
+          ) ?? "",
+        desc:
+          pickLocaleValue<string>(
+            child.fields?.desc,
+            localeCode,
+            fallbackLocaleCode,
+          ) ?? "",
+        image,
+      });
+    }
+
+    return {
+      title:
+        pickLocaleValue<string>(entry.fields?.title, localeCode, fallbackLocaleCode) ??
+        "",
+      items: resolvedItems,
+    };
+  },
+
+  "luminous.services": async ({ cfg, entry, includes, localeCode, fallbackLocaleCode }) => {
+    const items =
+      pickLocaleValue<any[]>(entry.fields?.items, localeCode, fallbackLocaleCode) ||
+      [];
+
+    const resolvedItems: any[] = [];
+    for (const it of items) {
+      const child = await resolveEntry(cfg, it, includes);
+      if (!child) continue;
+
+      const image = await resolveAssetUrl(
+        cfg,
+        pickLocaleValue<any>(
+          child.fields?.image,
+          localeCode,
+          fallbackLocaleCode,
+        ),
+        localeCode,
+        fallbackLocaleCode,
+        includes,
+      );
+
+      resolvedItems.push({
+        title:
+          pickLocaleValue<string>(
+            child.fields?.title,
+            localeCode,
+            fallbackLocaleCode,
+          ) ?? "",
+        desc:
+          pickLocaleValue<string>(
+            child.fields?.desc,
+            localeCode,
+            fallbackLocaleCode,
+          ) ?? "",
+        image,
+      });
+    }
+
+    return {
+      title:
+        pickLocaleValue<string>(entry.fields?.title, localeCode, fallbackLocaleCode) ??
+        "",
+      subtitle:
+        pickLocaleValue<string>(
+          entry.fields?.subtitle,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+      items: resolvedItems,
+    };
+  },
+
+  "luminous.process": async ({ cfg, entry, includes, localeCode, fallbackLocaleCode }) => {
+    const steps =
+      pickLocaleValue<any[]>(entry.fields?.steps, localeCode, fallbackLocaleCode) ||
+      [];
+
+    const resolvedSteps: any[] = [];
+    for (const it of steps) {
+      const child = await resolveEntry(cfg, it, includes);
+      if (!child) continue;
+
+      resolvedSteps.push({
+        number:
+          pickLocaleValue<string>(
+            child.fields?.number,
+            localeCode,
+            fallbackLocaleCode,
+          ) ?? "",
+        title:
+          pickLocaleValue<string>(
+            child.fields?.title,
+            localeCode,
+            fallbackLocaleCode,
+          ) ?? "",
+        description:
+          pickLocaleValue<string>(
+            child.fields?.description,
+            localeCode,
+            fallbackLocaleCode,
+          ) ?? "",
+      });
+    }
+
+    return {
+      title:
+        pickLocaleValue<string>(entry.fields?.title, localeCode, fallbackLocaleCode) ??
+        "",
+      intro:
+        pickLocaleValue<string>(entry.fields?.intro, localeCode, fallbackLocaleCode) ??
+        "",
+      steps: resolvedSteps,
+    };
+  },
+
+  "luminous.team": async ({ cfg, entry, includes, localeCode, fallbackLocaleCode }) => {
+    const members =
+      pickLocaleValue<any[]>(
+        entry.fields?.members,
+        localeCode,
+        fallbackLocaleCode,
+      ) || [];
+
+    const resolvedMembers: any[] = [];
+    for (const it of members) {
+      const child = await resolveEntry(cfg, it, includes);
+      if (!child) continue;
+
+      const image = await resolveAssetUrl(
+        cfg,
+        pickLocaleValue<any>(
+          child.fields?.image,
+          localeCode,
+          fallbackLocaleCode,
+        ),
+        localeCode,
+        fallbackLocaleCode,
+        includes,
+      );
+
+      resolvedMembers.push({
+        name:
+          pickLocaleValue<string>(
+            child.fields?.name,
+            localeCode,
+            fallbackLocaleCode,
+          ) ?? "",
+        description:
+          pickLocaleValue<string>(
+            child.fields?.description,
+            localeCode,
+            fallbackLocaleCode,
+          ) ?? "",
+        image,
+        specialties:
+          pickLocaleValue<string[]>(
+            child.fields?.specialties,
+            localeCode,
+            fallbackLocaleCode,
+          ) || [],
+      });
+    }
+
+    return {
+      title:
+        pickLocaleValue<string>(entry.fields?.title, localeCode, fallbackLocaleCode) ??
+        "",
+      members: resolvedMembers,
+    };
+  },
+
+  "luminous.contact": async ({ entry, localeCode, fallbackLocaleCode }) => {
+    return {
+      title:
+        pickLocaleValue<string>(entry.fields?.title, localeCode, fallbackLocaleCode) ??
+        "",
+      address:
+        pickLocaleValue<string>(
+          entry.fields?.address,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+      whatsapp:
+        pickLocaleValue<string>(
+          entry.fields?.whatsapp,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+      instagram:
+        pickLocaleValue<string>(
+          entry.fields?.instagram,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+      email:
+        pickLocaleValue<string>(entry.fields?.email, localeCode, fallbackLocaleCode) ??
+        "",
+      hours: {
+        weekdays:
+          pickLocaleValue<string>(
+            entry.fields?.hoursWeekdays,
+            localeCode,
+            fallbackLocaleCode,
+          ) ?? "",
+        saturday:
+          pickLocaleValue<string>(
+            entry.fields?.hoursSaturday,
+            localeCode,
+            fallbackLocaleCode,
+          ) ?? "",
+        sunday:
+          pickLocaleValue<string>(
+            entry.fields?.hoursSunday,
+            localeCode,
+            fallbackLocaleCode,
+          ) ?? "",
+      },
+    };
+  },
+
+  "luminous.footer": async ({ entry, localeCode, fallbackLocaleCode }) => {
+    return {
+      quote:
+        pickLocaleValue<string>(entry.fields?.quote, localeCode, fallbackLocaleCode) ??
+        "",
+      text:
+        pickLocaleValue<string>(entry.fields?.text, localeCode, fallbackLocaleCode) ??
+        "",
+    };
+  },
+
+  // styles handlers
+  "luminous.styles.generales": async ({ entry, localeCode, fallbackLocaleCode }) => {
+    return {
+      colors: {
+        primary:
+          pickLocaleValue<string>(
+            entry.fields?.primary,
+            localeCode,
+            fallbackLocaleCode,
+          ) ?? "",
+        secondary:
+          pickLocaleValue<string>(
+            entry.fields?.secondary,
+            localeCode,
+            fallbackLocaleCode,
+          ) ?? "",
+      },
+      typography: {
+        fontFamily:
+          pickLocaleValue<string>(
+            entry.fields?.fontFamily,
+            localeCode,
+            fallbackLocaleCode,
+          ) ?? "",
+        baseSize:
+          pickLocaleValue<number>(
+            entry.fields?.baseSize,
+            localeCode,
+            fallbackLocaleCode,
+          ) ?? 16,
+      },
+      assets: {
+        logoUrl:
+          pickLocaleValue<string>(
+            entry.fields?.logoUrl,
+            localeCode,
+            fallbackLocaleCode,
+          ) ?? "",
+      },
+    };
+  },
+
+  "luminous.styles.header": async ({ entry, localeCode, fallbackLocaleCode }) => {
+    return {
+      title1Color:
+        pickLocaleValue<string>(
+          entry.fields?.title1Color,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+      title2Color:
+        pickLocaleValue<string>(
+          entry.fields?.title2Color,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+      title1Size:
+        pickLocaleValue<number>(
+          entry.fields?.title1Size,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? 48,
+      title2Size:
+        pickLocaleValue<number>(
+          entry.fields?.title2Size,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? 40,
+      subtitle1Color:
+        pickLocaleValue<string>(
+          entry.fields?.subtitle1Color,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+      subtitle2Color:
+        pickLocaleValue<string>(
+          entry.fields?.subtitle2Color,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+    };
+  },
+
+  "luminous.styles.about": async ({ entry, localeCode, fallbackLocaleCode }) => {
+    return {
+      titleColor:
+        pickLocaleValue<string>(
+          entry.fields?.titleColor,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+      bodyColor:
+        pickLocaleValue<string>(
+          entry.fields?.bodyColor,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+      backgroundColor:
+        pickLocaleValue<string>(
+          entry.fields?.backgroundColor,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+      titleSize:
+        pickLocaleValue<number>(
+          entry.fields?.titleSize,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? 50,
+      bodySize:
+        pickLocaleValue<number>(
+          entry.fields?.bodySize,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? 18,
+      backgroundImage:
+        pickLocaleValue<string>(
+          entry.fields?.backgroundImage,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+    };
+  },
+
+  "luminous.styles.spaces": async ({ entry, localeCode, fallbackLocaleCode }) => {
+    return {
+      textColor:
+        pickLocaleValue<string>(
+          entry.fields?.textColor,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+      speedSeconds:
+        pickLocaleValue<number>(
+          entry.fields?.speedSeconds,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? 25.6,
+    };
+  },
+
+  "luminous.styles.therapies": async ({ entry, localeCode, fallbackLocaleCode }) => {
+    return {
+      titleColor:
+        pickLocaleValue<string>(
+          entry.fields?.titleColor,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+      itemTitleColor:
+        pickLocaleValue<string>(
+          entry.fields?.itemTitleColor,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+      itemDescColor:
+        pickLocaleValue<string>(
+          entry.fields?.itemDescColor,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+    };
+  },
+
+  "luminous.styles.services": async ({ entry, localeCode, fallbackLocaleCode }) => {
+    return {
+      titleColor:
+        pickLocaleValue<string>(
+          entry.fields?.titleColor,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+      subtitleColor:
+        pickLocaleValue<string>(
+          entry.fields?.subtitleColor,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+      itemTitleColor:
+        pickLocaleValue<string>(
+          entry.fields?.itemTitleColor,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+    };
+  },
+
+  "luminous.styles.process": async ({ entry, localeCode, fallbackLocaleCode }) => {
+    return {
+      titleColor:
+        pickLocaleValue<string>(
+          entry.fields?.titleColor,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+      introColor:
+        pickLocaleValue<string>(
+          entry.fields?.introColor,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+      stepTitleColor:
+        pickLocaleValue<string>(
+          entry.fields?.stepTitleColor,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+      stepDescColor:
+        pickLocaleValue<string>(
+          entry.fields?.stepDescColor,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+    };
+  },
+
+  "luminous.styles.team": async ({ entry, localeCode, fallbackLocaleCode }) => {
+    return {
+      titleColor:
+        pickLocaleValue<string>(
+          entry.fields?.titleColor,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+      nameColor:
+        pickLocaleValue<string>(
+          entry.fields?.nameColor,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+      roleColor:
+        pickLocaleValue<string>(
+          entry.fields?.roleColor,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+    };
+  },
+
+  "luminous.styles.contact": async ({ entry, localeCode, fallbackLocaleCode }) => {
+    return {
+      titleColor:
+        pickLocaleValue<string>(
+          entry.fields?.titleColor,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+      infoColor:
+        pickLocaleValue<string>(
+          entry.fields?.infoColor,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+    };
+  },
+
+  "luminous.styles.footer": async ({ entry, localeCode, fallbackLocaleCode }) => {
+    return {
+      textColor:
+        pickLocaleValue<string>(
+          entry.fields?.textColor,
+          localeCode,
+          fallbackLocaleCode,
+        ) ?? "",
+    };
+  },
+};
+
+async function tryGetStructuredContent(
+  cfg: ContentfulStoreConfig,
+  locale: Locale,
+  resolved: ResolvedLocales,
+  key: string,
+) {
+  const contentType = STRUCTURED_KEY_TO_CONTENT_TYPE[key];
+  const handler = structuredHandlers[key];
+  if (!contentType || !handler) return undefined;
+
+  const { item, includes } = await findDeliveryEntryByKey(
+    cfg,
+    contentType,
+    key,
+    resolved.defaultLocale,
+  );
+
+  if (!item) return null;
+
+  const localeCode = resolved.localeMap[locale] || resolved.defaultLocale;
+  const data = await handler({
+    cfg,
+    entry: item,
+    includes,
+    localeCode,
+    fallbackLocaleCode: resolved.defaultLocale,
+  });
+
+  return data;
+}
+
 export async function contentfulGetContent<T = any>(
   key: string,
   locale: Locale,
@@ -253,6 +1218,11 @@ export async function contentfulGetContent<T = any>(
   const resolved = await resolveLocales(cfg);
 
   try {
+    const structured = await tryGetStructuredContent(cfg, locale, resolved, key);
+    if (structured !== undefined) {
+      return { configured: true as const, data: (structured as any) as T | null };
+    }
+
     const entry: any = await findContentEntryByKey(
       cfg,
       key,

--- a/server/contentful-store.ts
+++ b/server/contentful-store.ts
@@ -459,6 +459,7 @@ const STRUCTURED_KEY_TO_CONTENT_TYPE: Record<string, string> = {
   "luminous.contact": STRUCTURED_CONTENT_TYPES.contact,
   "luminous.footer": STRUCTURED_CONTENT_TYPES.footer,
 
+  // styles (legacy: separate entries/types)
   "luminous.styles.generales": STRUCTURED_CONTENT_TYPES.stylesGenerales,
   "luminous.styles.header": STRUCTURED_CONTENT_TYPES.stylesHeader,
   "luminous.styles.about": STRUCTURED_CONTENT_TYPES.stylesAbout,
@@ -469,6 +470,21 @@ const STRUCTURED_KEY_TO_CONTENT_TYPE: Record<string, string> = {
   "luminous.styles.team": STRUCTURED_CONTENT_TYPES.stylesTeam,
   "luminous.styles.contact": STRUCTURED_CONTENT_TYPES.stylesContact,
   "luminous.styles.footer": STRUCTURED_CONTENT_TYPES.stylesFooter,
+};
+
+// Unification: allow reading section styles from the same section entry.
+// Example: key "luminous.styles.about" will read from entry key "luminous.about" (content type dbtAbout)
+// so editors manage content + styles in one place.
+const UNIFIED_STYLE_KEY_TO_BASE_KEY: Record<string, string> = {
+  "luminous.styles.header": "luminous.header",
+  "luminous.styles.about": "luminous.about",
+  "luminous.styles.spaces": "luminous.spaces",
+  "luminous.styles.therapies": "luminous.therapies",
+  "luminous.styles.services": "luminous.services",
+  "luminous.styles.process": "luminous.process",
+  "luminous.styles.team": "luminous.team",
+  "luminous.styles.contact": "luminous.contact",
+  "luminous.styles.footer": "luminous.footer",
 };
 
 const structuredHandlers: Record<string, StructuredKeyHandler> = {
@@ -992,7 +1008,19 @@ const structuredHandlers: Record<string, StructuredKeyHandler> = {
     };
   },
 
-  "luminous.styles.about": async ({ entry, localeCode, fallbackLocaleCode }) => {
+  "luminous.styles.about": async ({ cfg, entry, includes, localeCode, fallbackLocaleCode }) => {
+    const backgroundImage = await resolveAssetUrl(
+      cfg,
+      pickLocaleValue<any>(
+        entry.fields?.backgroundImage,
+        localeCode,
+        fallbackLocaleCode,
+      ),
+      localeCode,
+      fallbackLocaleCode,
+      includes,
+    );
+
     return {
       titleColor:
         pickLocaleValue<string>(
@@ -1024,12 +1052,7 @@ const structuredHandlers: Record<string, StructuredKeyHandler> = {
           localeCode,
           fallbackLocaleCode,
         ) ?? 18,
-      backgroundImage:
-        pickLocaleValue<string>(
-          entry.fields?.backgroundImage,
-          localeCode,
-          fallbackLocaleCode,
-        ) ?? "",
+      backgroundImage,
     };
   },
 

--- a/server/contentful-store.ts
+++ b/server/contentful-store.ts
@@ -1241,7 +1241,16 @@ function isStructuredResultEmpty(key: string, data: any) {
   // styles
   if (key.startsWith("luminous.styles.")) {
     // If nothing is set, keep using legacy JSON so existing styling doesn't change.
-    return !JSON.stringify(data).replace(/\s+/g, "").includes("#");
+    const stack: any[] = [data];
+    while (stack.length) {
+      const cur = stack.pop();
+      if (typeof cur === "string" && cur.trim().length > 0) return false;
+      if (typeof cur === "number" && Number.isFinite(cur)) return false;
+      if (cur && typeof cur === "object") {
+        for (const v of Object.values(cur)) stack.push(v);
+      }
+    }
+    return true;
   }
 
   return false;

--- a/server/contentful-store.ts
+++ b/server/contentful-store.ts
@@ -225,6 +225,7 @@ async function findContentEntryByKey(
   const q: Record<string, any> = {
     content_type: cfg.contentTypeContentEntry,
     limit: 1,
+    include: 10,
   };
   q[`fields.${cfg.fieldKey}`] = key;
 

--- a/server/contentful-store.ts
+++ b/server/contentful-store.ts
@@ -1285,6 +1285,42 @@ export async function contentfulListKeys(prefix?: string) {
       if (skip >= total || page.items.length === 0) break;
     }
 
+    // Also include structured types (if they exist). This keeps the in-app admin
+    // key list useful even when the site is managed via structured Contentful models.
+    const structuredTypes = Array.from(
+      new Set(Object.values(STRUCTURED_KEY_TO_CONTENT_TYPE)),
+    );
+
+    for (const ct of structuredTypes) {
+      try {
+        let s = 0;
+        while (true) {
+          const page = await allLocalesClient.getEntries({
+            content_type: ct,
+            select: `fields.${cfg.fieldKey}`,
+            limit,
+            skip: s,
+          });
+
+          for (const item of page.items as any[]) {
+            const k = pickLocaleValue<string>(
+              item.fields?.[cfg.fieldKey],
+              resolved.defaultLocale,
+              resolved.defaultLocale,
+            );
+            if (typeof k === "string" && (!prefix || k.startsWith(prefix)))
+              keys.add(k);
+          }
+
+          const total = page.total ?? 0;
+          s += page.items.length;
+          if (s >= total || page.items.length === 0) break;
+        }
+      } catch (e: any) {
+        if (!isUnknownContentTypeError(e)) throw e;
+      }
+    }
+
     return { configured: true as const, keys: Array.from(keys).sort() };
   } catch (e: any) {
     if (isUnknownContentTypeError(e)) {

--- a/server/contentful-store.ts
+++ b/server/contentful-store.ts
@@ -1285,9 +1285,40 @@ async function tryGetStructuredContent(
   resolved: ResolvedLocales,
   key: string,
 ) {
-  const contentType = STRUCTURED_KEY_TO_CONTENT_TYPE[key];
   const handler = structuredHandlers[key];
-  if (!contentType || !handler) return undefined;
+  if (!handler) return undefined;
+
+  // Unified mode: style keys can be read from the corresponding section entry
+  // (single entry in Contentful for content + styles).
+  const unifiedBaseKey = UNIFIED_STYLE_KEY_TO_BASE_KEY[key];
+  if (unifiedBaseKey) {
+    const unifiedContentType = STRUCTURED_KEY_TO_CONTENT_TYPE[unifiedBaseKey];
+    if (unifiedContentType) {
+      const { item, includes } = await findDeliveryEntryByKey(
+        cfg,
+        unifiedContentType,
+        unifiedBaseKey,
+        resolved.defaultLocale,
+      );
+
+      if (item) {
+        const localeCode = resolved.localeMap[locale] || resolved.defaultLocale;
+        const data = await handler({
+          cfg,
+          entry: item,
+          includes,
+          localeCode,
+          fallbackLocaleCode: resolved.defaultLocale,
+        });
+
+        if (!isStructuredResultEmpty(key, data)) return data;
+      }
+    }
+  }
+
+  // Legacy mode: separate content types/entries per style key.
+  const contentType = STRUCTURED_KEY_TO_CONTENT_TYPE[key];
+  if (!contentType) return undefined;
 
   const { item, includes } = await findDeliveryEntryByKey(
     cfg,


### PR DESCRIPTION
## Purpose
To unify Contentful style components with their corresponding content entries (e.g., merging style fields into the main section entry like "About"), simplifying content management as requested.

## Code changes
- **Contentful Integration**: Added `structuredHandlers` and logic in `contentful.ts` to resolve style keys (e.g., `luminous.styles.about`) directly from the corresponding content entry (`luminous.about`) when available.
- **Admin UI**: Added a new "Access" tab in the Admin panel (`AdminAccessList`) to display user access information.
- **CMS Client**: Improved `apiFetchJson` in `cms.ts` with robust timeout handling and retry logic; updated `listContentKeys` to return the active CMS backend type.
- **mappings**: Defined mapping logic (`UNIFIED_STYLE_KEY_TO_BASE_KEY`) to link style configuration keys to their parent content types.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/93855f88c32d420fac57696471367434/zenith-haven)

👀 [Preview Link](https://93855f88c32d420fac57696471367434-zenith-haven.projects.builder.my/)

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>93855f88c32d420fac57696471367434</projectId>-->
<!--<branchName>zenith-haven</branchName>-->